### PR TITLE
User docs: supported conversions tables cleanup for connectors

### DIFF
--- a/user/autocadcivil.md
+++ b/user/autocadcivil.md
@@ -38,25 +38,46 @@ Any layer information from the incoming stream will be appended to the prefix wi
 ## Supported elements
 
 **AUTOCAD**
-| Geometry | Send | Receive | Status |
-| -------- | ---- | ------- | ------ |
-| Point | x | x | `Complete` |
-| Line | x | x | `Complete` |
-| Arc | x | x | `Complete` |
-| Circle | x | x | `Complete` |
-| Ellipse | x | x | `Complete` |
-| Polyline | x | x | `Complete` |
-| Polycurve | x | x | `Complete` |
-| Spline | x | x | `Complete` |
-| Surface | | | `In Progress` |
-| Polysurface | | | `In Progress` |
-| Nurbs Surface | | | `In Progress` |
-| Brep | | | `In Progress` |
+| Geometry       | Send | Receive | Status        |
+| -------------- | ---- | ------- | ------------- |
+| Point          | x    | x       | `Complete`    |
+| Line           | x    | x       | `Complete`    |
+| Arc            | x    | x       | `Complete`    |
+| Circle         | x    | x       | `Complete`    |
+| Ellipse        | x    | x       | `Complete`    |
+| Polyline       | x    | x       | `Complete`    |
+| Polycurve      | x    | x       | `Complete`    |
+| Spline         | x    | x       | `Complete`    |
+| Plane Surface  | x    |         | `In Progress` |
+| Nurb Surface   | x    |         | `In Progress` |
+| PolyFace Mesh  | x    |         | `In Progress` |
+| SubD Mesh      | x    |         | `In Progress` |
+
+| BuiltElement   | Send | Receive | Status        |
+| -------------- | ---- | ------- | ------------- |
+
+| Other          | Send | Receive | Status        |
+| -------------- | ---- | ------- | ------------- |
+| BlockInstance  |      |         | `In Progress` |
+| BlockDefinition|      |         | `In Progress` |
 
 **CIVIL3D**
-| Geometry | Send | Receive | Status |
-| -------- | ---- | ------- | ------ |
-| Featureline | x | | `In Progress` |
+| Geometry      | Send | Receive | Status        |
+| ------------- | ---- | ------- | ------------- |
+| Featureline   | x    |         | `In Progress` |
+| Alignment     |      |         | `In Progress` |
+| Profile       |      |         | `In Progress` |
+| Tin Surface   |      |         | `In Progress` |
+| Grid Surface  |      |         | `In Progress` |
+| Pipe          |      |         | `In Progress` |
+
+### Unsupported elements
+
+**AUTOCAD**
+Breps and hatches are not supported.
+
+**CIVIL3D**
+Subassemblies and Assemblies are not supported.
 
 ### Things to keep in mind
 

--- a/user/autocadcivil.md
+++ b/user/autocadcivil.md
@@ -53,9 +53,6 @@ Any layer information from the incoming stream will be appended to the prefix wi
 | PolyFace Mesh  | x    |         | `In Progress` |
 | SubD Mesh      | x    |         | `In Progress` |
 
-| BuiltElement   | Send | Receive | Status        |
-| -------------- | ---- | ------- | ------------- |
-
 | Other          | Send | Receive | Status        |
 | -------------- | ---- | ------- | ------------- |
 | BlockInstance  |      |         | `In Progress` |
@@ -74,9 +71,11 @@ Any layer information from the incoming stream will be appended to the prefix wi
 ### Unsupported elements
 
 **AUTOCAD**
+
 Breps and hatches are not supported.
 
 **CIVIL3D**
+
 Subassemblies and Assemblies are not supported.
 
 ### Things to keep in mind

--- a/user/dynamo.md
+++ b/user/dynamo.md
@@ -352,3 +352,28 @@ Creates a connection to a specific file in the computer's disk, where the data w
 ![Memory transport](./img-dyn/nodes-transport-memory.png)
 
 Creates a connection to in-memory storage.
+
+## Supported elements
+
+| Geometry       | Send        | Receive | Status        |
+| -------------- | ----------- | ------- | ------------- |
+| Point          | x           | x       | `Complete`    |
+| Line           | x           | x       | `Complete`    |
+| Plane          | x           | x       | `Complete`    |
+| Arc            | x           | x       | `Complete`    |
+| Circle         | x           | x       | `Complete`    |
+| Cuboid         | As Box      | x       | `Complete`    |
+| Ellipse        | x           | x       | `Complete`    |
+| Helix          | As Spline   |         | `Complete`    |
+| Polyline       |             | As Rectangle, Polycurve, or Polygon| `Complete`    |
+| Polycurve      | x           | x       | `Complete`    |
+| Polygon        | As Polyline | x       | `Complete`    |
+| Rectangle      | As Polyline | x       | `Complete`    |
+| Spline         | x           | x       | `Complete`    |
+| Brep           | x           | x       | `Complete`    |
+| Mesh           | x           | x       | `Complete`    |
+
+
+### Unsupported elements
+
+Any geometric element not listed above are not supported.

--- a/user/grasshopper.md
+++ b/user/grasshopper.md
@@ -170,6 +170,61 @@ When you activate any of the previous options, the corresponding icon will be sh
 
 :::
 
+## Supported elements
+
+Grasshopper supports the same geometry as the Rhino connector:
+
+| Geometry       | Send    | Receive | Status        |
+| -------------- | ------- | ------- | ------------- |
+| Point          | x       | x       | `Complete`    |
+| Line           | x       | x       | `Complete`    |
+| Plane          | x       | x       | `Complete`    |
+| Arc            | x       | x       | `Complete`    |
+| Circle         | x       | x       | `Complete`    |
+| Ellipse        | x       | x       | `Complete`    |
+| Polyline       | x       | x       | `Complete`    |
+| Polycurve      | x       | x       | `Complete`    |
+| Spline         | x       | x       | `Complete`    |
+| Nurb Surface   | As Brep | x       | `Complete`    |
+| Brep           | x       | x       | `Complete`    |
+| Extrusion      | x       | As Brep | `Complete`    |
+| Mesh           | x       | x       | `Complete`    |
+
+| Other          | Send    | Receive | Status        |
+| -------------- | ------- | ------- | ------------- |
+| RenderMaterial | x       |         | `In Progress` |
+
+The **Schema Builder** node also provides additional support for the following built elements:
+
+| BuiltElement                                          | Send    | Receive | Status        |
+| ----------------------------------------------------- | ------- | ------- | ------------- |
+| Adaptive Component                                    | x       |         | `Complete`    |
+| Beam                                                  | x       |         | `Complete`    |
+| Brace                                                 | x       |         | `Complete`    |
+| Ceiling                                               | x       |         | `Complete`    |
+| Column                                                | x       |         | `Complete`    |
+| Curves (Model, Detail, Room Boundary)                 | x       |         | `Complete`    |
+| Direct Shape                                          | x       |         | `Complete`    |
+| Duct                                                  | x       |         | `Complete`    |
+| Face Wall                                             | x       |         | `Complete`    |
+| Family Instance                                       | x       |         | `Complete`    |
+| Floor                                                 | x       |         | `Complete`    |
+| GridLine                                              | x       |         | `Complete`    |
+| Level                                                 | x       |         | `Complete`    |
+| Opening (Wall, Vertical, Shaft)                       | x       |         | `Complete`    |
+| Parameter                                             | x       |         | `Complete`    |
+| Railing                                               | x       |         | `Complete`    |
+| Roof (Extrusion, Footprint)                           | x       |         | `Complete`    |
+| Topography                                            | x       |         | `Complete`    |
+| View                                                  |         |         | `In Progress` |
+| Wall                                                  | x       |         | `Complete`    |
+
+Refer to the section below for additional information on the **Schema Builder** node.
+
+### Unsupported elements
+
+Non-geometric elements and any geometric element not listed above, such as text tags, hatches, etc... are not supported.
+
 ## Schema Builder
 
 ![Schema Builder node](./img-gh/nodes-schema-builder.png)

--- a/user/revit.md
+++ b/user/revit.md
@@ -58,40 +58,42 @@ We're working hard to support additional elements, the list below will be update
 
 If you'd like us to add something specific let us know on the [forum](https://speckle.community/t/speckle-unity-2-0-feedback-wanted/1108)!
 
-| Type                                                  | Speckle > Revit | Revit > Speckle |
-| ----------------------------------------------------- | --------------- | --------------- |
-| Adaptive Component                                    | x               | x               |
-| Beam                                                  | x               | x               |
-| Brace                                                 | x               | x               |
-| Building Pad                                          |                 | x               |
-| Ceiling                                               |                 | x               |
-| Curves (Model, Detail, Room Boundary)                 | x               | x               |
-| Direct Shape                                          | x               | x               |
-| Duct                                                  | x               | x               |
-| Face Wall                                             | x               |                 |
-| Family Instance                                       | x               | x               |
-| Floor                                                 | x               | x               |
-| Group                                                 |                 | x               |
-| Level                                                 | x               | x               |
-| Opening (Wall, Vertical, Shaft)                       | x               | x               |
-| Project Information                                   |                 | x               |
-| Railing                                               | x               | x               |
-| Roof (Extrusion, Footprint)                           | x               | x               |
-| Room                                                  |                 | x               |
-| Stair                                                 |                 | x               |
-| Topography                                            | x               | x               |
-| View (FloorPlan, CeilingPlan, Elevation, Section, 3D) |                 | x               |
-| Wall                                                  | x               | x               |
+| BuiltElement                                          | Send    | Receive | Status        |
+| ----------------------------------------------------- | ------- | ------- | ------------- |
+| Adaptive Component                                    | x       | x       | `Complete`    |
+| Beam                                                  | x       | x       | `Complete`    |
+| Brace                                                 | x       | x       | `Complete`    |
+| Building Pad                                          | x       |         | `In Progress` |
+| Ceiling                                               | x       |         | `In Progress` |
+| Curves (Model, Detail, Room Boundary)                 | x       | x       | `Complete`    |
+| Direct Shape                                          | x       | x       | `Complete`    |
+| Duct                                                  | x       | x       | `Complete`    |
+| Face Wall                                             |         | x       | `In Progress` |
+| Family Instance                                       | x       | x       | `Complete`    |
+| Floor                                                 | x       | x       | `Complete`    |
+| Group                                                 | x       |         | `In Progress` |
+| Level                                                 | x       | x       | `Complete`    |
+| Opening (Wall, Vertical, Shaft)                       | x       | x       | `Complete`    |
+| Project Information                                   | x       |         | `In Progress` |
+| Railing                                               | x       | x       | `Complete`    |
+| Roof (Extrusion, Footprint)                           | x       | x       | `Complete`    |
+| Room                                                  | x       |         | `Complete`    |
+| Stair                                                 | x       |         | `Complete`    |
+| Topography                                            | x       | x       | `Complete`    |
+| View (FloorPlan, CeilingPlan, Elevation, Section, 3D) | x       |         | `In Progress` |
+| Wall                                                  | x       | x       | `Complete`    |
 
-#### Raw Geometry
+| Other                                                 | Send    | Receive | Status        |
+| ----------------------------------------------------- | ------- | ------- | ------------- |
+| RenderMaterial                                        |         |         | `In Progress` |
 
 Generally speaking, Revit doesn't support raw geometry as it deals with families. Nonetheless, we've made it simple to receive some types of geometry directly, without the need of specifying family type, name or any other parameter.
 
-| Type         | Speckle > Revit                          |
-| ------------ | ---------------------------------------- |
-| Line & Curve | Model Curves                             |
-| Brep         | Direct Shape with Generic Model category |
-| Mesh         | Direct Shape with Generic Model category |
+| Geometry                                              | Send    | Receive        | Status        |
+| ----------------------------------------------------- | ------- | -------------- | ------------- |
+| Line & Curve                                          |         | As ModelCurve  | `In Progress` |
+| Brep                                                  |         | As DirectShape | `Complete`    |
+| Mesh                                                  |         | As DirectShape | `Complete`    |
 
 ### Non Supported Elements
 

--- a/user/rhino.md
+++ b/user/rhino.md
@@ -72,11 +72,35 @@ as well as the overlapping received objects(gray) with the original objects (blu
 
 ## Supported elements
 
-When sending data from Rhino, almost all geometric elements are supported. This includes:
+Almost all geometric elements are supported by the Rhino connector. This includes:
 
-- Vector entities (point, vector, plane)
-- Curve entities (line, curve, polylines, polycurves, NURBS...)
-- Surface entities (surfaces, meshes and breps)
+| Geometry       | Send    | Receive | Status        |
+| -------------- | ------- | ------- | ------------- |
+| Point          | x       | x       | `Complete`    |
+| Line           | x       | x       | `Complete`    |
+| Plane          | x       | x       | `Complete`    |
+| Arc            | x       | x       | `Complete`    |
+| Circle         | x       | x       | `Complete`    |
+| Ellipse        | x       | x       | `Complete`    |
+| Polyline       | x       | x       | `Complete`    |
+| Polycurve      | x       | x       | `Complete`    |
+| Spline         | x       | x       | `Complete`    |
+| Nurb Surface   | As Brep | x       | `Complete`    |
+| Brep           | x       | x       | `Complete`    |
+| Extrusion      | x       | As Brep | `Complete`    |
+| Mesh           | x       | x       | `Complete`    |
+
+| BuiltElement   | Send    | Receive | Status        |
+| -------------- | ------- | ------- | ------------- |
+| View           | x       | x       | `Complete`    |
+| ModelCurve     |         | As Curve| `Complete`    |
+| DirectShape    |         | As Mesh | `Complete`    |
+
+| Other          | Send    | Receive | Status        |
+| -------------- | ------- | ------- | ------------- |
+| RenderMaterial | x       |         | `In Progress` |
+| BlockInstance  |         |         | `In Progress` |
+| BlockDefinition|         |         | `In Progress` |
 
 > We fully support sending BREPs from Rhino <-> Rhino, and Rhino <-> Revit with some limitations imposed by the Revit API.
 


### PR DESCRIPTION
Added a `Supported elements` and `Unsupported elements` section to all connector user docs, with the following organization:

[Geometry/BuiltElement/Other] [Send] [Receive] [Status]

Specifies when conversion type changes in the table.

Closes #35 