### PR TITLE
Fixed url typos

### DIFF
--- a/dev/architecture.md
+++ b/dev/architecture.md
@@ -38,7 +38,7 @@ Existing authoring applications, such as Rhino, Revit, Autocad, send and receive
 
 Read more about **Kits** [here](/dev/kits). If curious, you can also follow up with the discussion on [our forum](https://speckle.community/t/introducing-kits-2-0/710).
 
-We also have a guide on how to write your own **Connector** - [check it out](http://localhost:8080/dev/connectors-dev.html)!
+We also have a guide on how to write your own **Connector** - [check it out](/dev/connectors-dev.html)!
 
 :::
 

--- a/dev/connectors-dev.md
+++ b/dev/connectors-dev.md
@@ -325,7 +325,7 @@ For any questions feel free to write on the [community forum](https://speckle.co
 
 If the host app you're targeting uses object types not currently defined in the Objects Kit and you'd like to write conversions for them, we are happy to extend it! 
 
-Please get in touch on the forum before making a PR, then have a look at [how to write new objects](http://localhost:8080/dev/objects.html#writing-objects).
+Please get in touch on the forum before making a PR, then have a look at [how to write new objects](/dev/objects.html#writing-objects).
 
 ## Loading the Converter
 


### PR DESCRIPTION
quick fix to two urls that has `localhost:8080` hard-coded