### PR TITLE
Update web.md

### DIFF
--- a/user/web.md
+++ b/user/web.md
@@ -183,7 +183,7 @@ branch = client.branch.get(stream_id, "globals")
 latest_commit = branch.commits.items[0]
 
 # receive the globals object
-globals = operations.receive(latest_commit.referencedObject, transport)
+globs = operations.receive(latest_commit.referencedObject, transport)
 ```
 
 ## Profile


### PR DESCRIPTION
fixed variable name from "globals" to "globs" inside code example (it was shadowing Python's language keyword/function)