### PR TITLE
feat(dev): Added SchemaInfo + SchemaDeprecated section in dev/objects.md

### DIFF
--- a/dev/objects.md
+++ b/dev/objects.md
@@ -59,8 +59,6 @@ public class Box : Base, IHasVolume, IHasArea, IHasBoundingBox
 }
 ```
 
-#### Adding `SchemaInfo` attributes to
-
 ### Specific Host Application Support
 
 The basic objects are intended to be as general as possible


### PR DESCRIPTION
We were missing a clear explanation on how to deal with breaking changes in classes that use `SchemaInfo`, as these changes will bubble up to GH, Rhino and any other place we eventually implement Schema creation.

Fixes #51, which was originally flagged as a GH thing, but I think it was better placed in the `Objects` section.