### PR TITLE
Specklepy examples corrections

### DIFF
--- a/dev/py-examples.md
+++ b/dev/py-examples.md
@@ -134,7 +134,7 @@ Interacting with streams is designed to be intuitive and evocative of SpecklePy 
 stream_list = client.stream.list()
 
 # search your streams
-results = client.user.search("mech")
+results = client.stream.search("mech")
 
 # create a stream
 new_stream_id = client.stream.create(name="a shiny new stream")

--- a/dev/py-examples.md
+++ b/dev/py-examples.md
@@ -203,6 +203,7 @@ You can also use the GraphQL API to send and receive objects. However, note that
 
 ```py
 from specklepy.objects import Base
+from specklepy.serialization.base_object_serializer import BaseObjectSerializer
 
 # create a test base object
 test_base = Base()

--- a/dev/py-examples.md
+++ b/dev/py-examples.md
@@ -154,7 +154,7 @@ commit = client.commit.get("stream_id", "commit_id")
 
 # create a commit
 commit_id = client.commit.create(
-    stream_id="stream_id", obj_id="object_id", message="this is a commit message to describe the commit")
+    stream_id="stream_id", object_id="object_id", message="this is a commit message to describe the commit")
 
 # delete a commit
 deleted = client.commit.delete("stream_id", "commit_id")

--- a/dev/py-examples.md
+++ b/dev/py-examples.md
@@ -192,7 +192,7 @@ hash = operations.send(base=base_obj, transports=[transport])
 # if the object had detached objects, you can see these as well
 saved_objects = transport.objects # a dict with the obj hash as the key
 
-# this receives and object from the given transport, deserialises it,
+# this receives an object from the given transport, deserialises it,
 # and recomposes it into a base object.
 # you can optionally provide a local_transport which will default to
 # the `SQLiteTransport` pointing at your local cache


### PR DESCRIPTION
* Stream search should be in stream scope not user
* Commit.create signature corrected (`obj_id` => `object_id`)
* Typos generally
* Add relevant imports for code block contexts