### PR TITLE
Adding to the example base_obj 

### DIFF
--- a/dev/py-examples.md
+++ b/dev/py-examples.md
@@ -185,6 +185,7 @@ from specklepy.transports.memory import MemoryTransport
 from specklepy.api import operations
 
 transport = MemoryTransport()
+base_obj = Base()
 
 # this serialises the object and sends it to the transport
 hash = operations.send(base=base_obj, transports=[transport])


### PR DESCRIPTION
@izzylys I missed this in the last PR

Last change required to have this example documentation a valid jupyter notebook.