### PR TITLE
added fe2 terminology to skp, rvt and pbi.

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -99,7 +99,6 @@ module.exports = {
             "connectors",
             "manager",
             "ui2",
-            "ui",
             {
               title: "Revit",
               collapsable: true,

--- a/user/FAQs.md
+++ b/user/FAQs.md
@@ -31,17 +31,17 @@ Speckle is licensed as Apache 2 so you are free to study, modify, redistribute a
 
 This means that you can totally deploy your own Speckle server without ever having to depend on us!
 
-## What is a Stream?
+## What is a Project?
 
-**Streams** are collections of data inside Speckle. You can see a stream as a folder, a project or a repository.
+**Projects** are collections of data inside Speckle. You can see a Project as a folder or a repository.
 
-## What is a Commit?
+## What is a Version?
 
-Data in a stream is stored in **commits**, which are snapshots of data in time. Every time you send to Speckle from a connector, a commit is created.
+Data in a Project is stored in **Versions**, which are snapshots of data in time. Every time you send to Speckle from a connector, a Version is created.
 
-## What is a Branch?
+## What is a Model?
 
-Commits can also be organized in **branches**, for instance, to have multiple design options or to store data by discipline. The default branch is called _main_.
+Versions can also be organized in **Models**, for instance, to have multiple design options or to store data by discipline. If a Project has only one Model and has no name it can be referred to as _main_.
 
 ## What is a Connector?
 
@@ -74,17 +74,17 @@ For any more questions about this, feel free to [contact us](https://speckle.sys
 
 Check our [troubleshooting section](/user/manager.html#troubleshooting) for Speckle Manager.
 
-## How do I merge two branches in Speckle
+## How do I merge two Models in Speckle
 
-Currently, commits, branches or streams cannot be merged via Speckle, but you can do so in most authoring software supported by Speckle. For instance, you can manually merge two branches (or even streams) easily in Grasshopper.
+Currently, Versions, Models or Projects cannot be merged via Speckle, but you can do so in most authoring software supported by Speckle or progammaticaly using our SDKs. For instance, you can manually merge two Models (or even Projects) easily in Grasshopper.
 
 ## Why can't I see anything in the 3D Viewer?
 
-Our 3D Viewer only supports visualizing geometry. If you're sending any data that doesn't have a supported geometrical representation it will not be visible, for example when sending a list of Levels or Revit Family and Type names. You'll always be able to explore the raw data of a Stream in the commit page, however.
+Our 3D Viewer only supports visualizing geometry. If you're sending any data that doesn't have a supported geometrical representation it will not be visible, for example when sending a list of Levels or Revit Family and Type names. You'll always be able to explore the raw data of a Project in the Version page, however.
 
 ## I forgot my password 🤔
 
-This time over, we've got you covered: just go to the [password reset page](https://speckle.xyz/authn/resetpassword)!
+This time over, we've got you covered: just go to the [password reset page](https://app.speckle.systems/authn/resetpassword)!
 
 ## More questions?
 

--- a/user/README.md
+++ b/user/README.md
@@ -10,9 +10,9 @@ Organizations all over the world rely on our collaboration, interoperability and
 
 ## What We'll Cover
 
-This guide provides an introduction to the key Speckle concepts you'll need to know. We'll go over what you need to install, how to [create an account](/user/quickstart.html#registration), and how to [send data](/user/ui.html#sending-data) to your first Speckle stream.
+This guide provides an introduction to the key Speckle concepts you'll need to know. We'll go over what you need to install, how to [create an account](/user/quickstart.html#registration), and how to [send data](/user/ui.html#sending-data) to your first Speckle project.
 
-We also have a few [tutorials](https://speckle.systems/tutorials/) which provide step-by-step guidance for several common workflows (e.g. sending data Rhino -> Revit and back).
+We also have a few [tutorials](https://speckle.systems/tutorials/) that provide step-by-step guidance for several common workflows (e.g. sending data Rhino -> Revit and back).
 
 If you're a programmer wanting to learn how to build things with Speckle, head over to our [developer docs](/dev/). If you're after some in-depth reading on how Speckle works under the hood, make sure to check the [core concepts section](/dev/base).
 
@@ -29,7 +29,7 @@ Speckle is made up of several moving parts. Before describing each in detail, le
 
 ![speckle-web-app (1)](https://user-images.githubusercontent.com/51519350/186359062-550b8805-1a43-448b-8153-92695c2307ce.png)
 
-The [Speckle Web App](/user/web) lets you manage and coordinate your data directly from your web browser. It includes a management interface to help you administer your various streams and a 3D model viewer to let see your projects.
+The [Speckle Web App](/user/web) lets you manage and coordinate your data directly from your web browser. It includes a management interface to help you administer your various projects and a 3D model viewer to let see your projects.
 
 ### Connectors
 

--- a/user/arcgis.md
+++ b/user/arcgis.md
@@ -32,9 +32,7 @@ In case you are using a custom conda environment for your project, or if install
 ### Features
 
 - The plugin allows you to select several layers in your project and send their geometry and attributes to a Speckle server.
-
 - You can receive Speckle geometry sent from other software. Properties of the objects upon receiving are stored in the layer attribute table.
-
 - You can send you data from ArcGIS and receive it in CAD in a CAD-friendly location, thanks to the option to create custom Spatial Reference (SR) in ArcGIS. To do this, you will be required to enter geographic coordinates of the point representing the origin point (0, 0) in your CAD project.
 
 ### Using Speckle ArcGIS
@@ -43,26 +41,26 @@ Once the plugin is installed, you'll find a new toolbox in Geoprocessing tools, 
 
 ![Speckle panel](./img-arcgis/interface.png)
 
-#### Adding a stream to the project
+#### Adding a Speckle project to the ArcGIS project
 
-First, you need to search and add a stream to the ArcGIS project. For that, you can press the Search button near the `Stream` panel. This will open a new pop-up window that will allow you to search for a specific stream and add it to ArcGIS project.
+First, you need to search and add a project to the ArcGIS project. For that, you can press the Search button near the `Project` panel. This will open a new pop-up window that will allow you to search for a specific project and add it to ArcGIS project.
 
-![Search stream panel](./img-arcgis/add_stream_img.png)
+![Search project panel](./img-arcgis/add_stream_img.png)
 
-From the list of streams in the dropdown list, you can select one to make it the **current active stream**. This will be the stream used for sending/receiving data. When an active stream is selected, the `Branch` dropdown will be populated with all available branches from that stream.
+From the list of projects in the dropdown list, you can select one to make it the **current active project**. This will be the project used for sending/receiving data. When an active project is selected, the `Model` dropdown will be populated with all available models from that project.
 
 And here's a short gif of the process 👇🏼
 
-![Adding a stream to the project](./img-arcgis/add_stream_gif.gif)
+![Adding a project to the project](./img-arcgis/add_stream_gif.gif)
 
-> Once a stream is added to the ArcGIS project, it is saved along with it so the streams will still be available after restarting ArcGIS.
+> Once a project is added to the ArcGIS project, it is saved along with it so the projects will still be available after restarting ArcGIS.
 
 #### Sending data
 
-1. Select a stream from the dropdown list.
-2. Specify a specific branch to send data to using the dropdown menu.
+1. Select a project from the dropdown list.
+2. Specify a specific model to send data to using the dropdown menu.
 3. Make visible the layers in the file that you wish to send.
-4. (optional) Write a commit message.
+4. (optional) Write a version message.
 5. (optional) If you want to receive it in a non-GIS software or view in the browser, make sure you the SR of your Active Map is of projected type (e.g. using Meters as units).
 6. Send the data.
 
@@ -86,10 +84,37 @@ Once data has been sent to Speckle, you can view the result by going to your Spe
 
 Steps to receive the data:
 
-1. Select the stream to receive data from
-2. Select the branch
-3. Select specific commit (by default the latest one)
-4. Find the received layers in the new layer group named after stream, branch and commit
+1. Select the project to receive data from
+2. Select the model
+3. Select specific version (by default the latest one)
+4. Find the received layers in the new layer group named after project, model and version
+
+![Receiving data](./img-arcgis/receive.gif)
+
+### Custom project center
+
+Modifying project center is useful when you need to:
+
+- Send data (so you can receive correctly in a non-GIS application)
+- Receive data (if data was sent from non-GIS application).
+
+You have several options to choose in order to set the custom project center.
+
+#### Adding offsets
+
+You can choose to use the existing Spatial Reference (SR of our Active Map) and modify it's Speckle properties by adding X- and Y- offsets. This option will only be affecting Speckle properties on Send/Receive and will not change anything for you while you are working on a ArcGIS project. Use this option when your project requires a use of a specific SR.
+
+For example, if you use a projected SR (e.g. EPSG:32631) without the offsets and send the Eiffel Tower outline to Speckle, when receiving in Rhino geometry will be located thousands kilometers away from the origin. But if before sending you set the offsets Lat(y) as 5411939.08 and Lon(x) as 448253.52, you will receive the Eiffel Tower right in the middle of your Rhino canvas, while still preserving the required SR (e.g. EPSG:32631).
+
+Lat(y) and Lon(x) offsets should be specified in the units of the Active Map SR, and in the correct order. Note, that when you copy the coordinates from ArcGIS canvas using right-click, the Lat/Lon order might be different depending on the SR used (Lat is usually marked with N-North, and Lon is marked with E-East, both values can be positive or negative).
+
+#### Creating custom SR
+
+Create a custom Spatial Reference, based on Traverse Mercator if you don't have to use a specific SR and want to have minimal size and shape distortions. Specify the origin Lat, Lon in geographic coordinates to create a custom SR with the required origin and change your Active Map SR.
+
+#### Adding angle to the True North
+
+You can also add an angle to the True North to either of the above options if your non-GIS application require so. It will only affect Speckle object properties during Send/Receive operations and will not be visible in ArcGIS project.
 
 ![Receiving data](./img-arcgis/receive.gif)
 

--- a/user/archicad.md
+++ b/user/archicad.md
@@ -36,11 +36,11 @@ This connector uses our shared Desktop UI. Read up on general guidelines for usa
 
 ### Sending Data
 
-After launching the connector, either create a new stream or select an existing one.
+After launching the connector, either create a new project or select an existing one.
 
 Next, select the objects you want to send from within the model viewer. Then in the send menu, click "Add selection".
 
-You can then write a commit message and click send. Once the send is complete, you'll be able to click the popup to view it in the browser.
+You can then write a message to label the version and click send. Once the send is complete, you'll be able to click the popup to view it in the browser.
 
 ![gif of the launch and send procedure in archicad](./img-archicad/archicad-send-process.gif)
 
@@ -48,7 +48,7 @@ You can then write a commit message and click send. Once the send is complete, y
 
 #### Into Archicad
 
-To receive data into Archicad, simply select a stream and click receive!
+To receive data into Archicad, simply select a project and click receive! Note that receiving into Archicad is currently not well supported. This is still an alpha and thus very work in progress!
 
 Feel free to drop suggestions and ideas about how you would like to use this connector on the [forum](https://speckle.community/) to help guide the development of this connector 🚀
 
@@ -56,15 +56,15 @@ Feel free to drop suggestions and ideas about how you would like to use this con
 
 Receiving Archicad models in other geometry focussed connectors (eg SketchUp, Rhino, Blender) is pretty well supported. Check out the images below for some examples!
 
-**Blender**
+##### Blender
 
 ![archicad to blender](./img-archicad/archicad-to-blender.png)
 
-**Rhino**
+##### Rhino
 
 ![archicad to rhino](./img-archicad/archicad-to-rhino.png)
 
-**SketchUp**
+##### SketchUp
 
 ![archicad to sketchup](./img-archicad/archicad-to-sketchup.png)
 

--- a/user/autocadcivil.md
+++ b/user/autocadcivil.md
@@ -15,9 +15,9 @@ Check out our dedicated tutorial on [how to get started with Civil3D](https://sp
 
 To begin, you'll need to install this Connector and add your Speckle account. Follow our instructions in [Speckle Manager](/user/manager) if you haven't already.
 
-Once installed, you can find this connector in the `Add-Ins` tab under `Speckle 2`. Clicking this button will open the Speckle connector interface, which shows a list of all the streams you currently have in the model.
+Once installed, you can find this connector in the `Add-Ins` tab under `Speckle 2`. Clicking this button will open the Speckle connector interface, which shows a list of all the projects you currently have in the model.
 
-![](./img-acad/setup-plugin.gif)
+![Setting up the Plugin](./img-acad/setup-plugin.gif)
 
 ## User Interface
 
@@ -33,15 +33,15 @@ The AutoCAD Civil3D Connector supports selection filtering by layer.
 
 ### Receiving Data
 
-Geometry from streams will be added to AutoCAD / Civil3D layers starting with a prefix with the following format:
+Geometry from projects will be added to AutoCAD / Civil3D layers starting with a prefix with the following format:
 
+```text
+project[ model @ version id ]
 ```
-stream[ branch @ commit id ]
-```
 
-Any layer information from the incoming stream will be appended to the prefix with the standard AutoCAD delimiter `$`. When receiving from applications (like Rhino) with nested layers, the incoming full layer path will replace any default delimiters with `$`.
+Any layer information from the incoming project will be appended to the prefix with the standard AutoCAD delimiter `$`. When receiving from applications (like Rhino) with nested layers, the incoming full layer path will replace any default delimiters with `$`.
 
-![](./img-acad/receiving-layers.png)
+![Screenshot of Layers showing th esource data](./img-acad/receiving-layers.png)
 
 ## Supported Elements
 

--- a/user/bentley.md
+++ b/user/bentley.md
@@ -6,7 +6,7 @@ The Bentley connectors are community-contributed: they were developed by Arup тн
 
 :::
 
-The Speckle 2.0 connector for Bentley software currently supports:
+The Speckle connector for Bentley software currently supports:
 
 - MicroStation CONNECT
 - OpenRoads Designer CE
@@ -17,27 +17,25 @@ The Speckle 2.0 connector for Bentley software currently supports:
 
 To install this Connector and add your Speckle account, follow the instructions in the [Speckle Manager](/user/manager) section.
 
-Once installed, you can find the connector in the `Speckle 2` ribbon. Click on the Connector button, and this will open a new pop-up window with the [Desktop UI](/user/ui.md). You'll also find the alpha version of our [new Desktop UI (alpha)](/user/ui2.md) if you'd like to give that a try, but be warned it is still unstable!
+Once installed, you can find the connector in the `Speckle 2` ribbon. Click on the Connector button, and this will open a new pop-up window with the standard [Desktop UI](/user/ui2.md)
 
 ![Speckle ribbon](./img-bentley/speckle-ribbon.png)
 
 ## User Interface
 
-> This connector uses our shared Desktop UI. Read up on general guidelines for usage in the [Desktop UI section](/user/ui) or give our [new Desktop UI (alpha)](/user/ui2.md) a try.
-
-Once the Desktop UI panel is open, go ahead and create a new stream (or add an existing one) to the current file. Once the Microstation, OpenRoads, OpenRail, or OpenBuildings file is saved, the streams associated with that file will be saved too.
+Once the Speckle panel is open, go ahead and create a new project (or add an existing one) to the current file. Once the Microstation, OpenRoads, OpenRail, or OpenBuildings file is saved, the projects associated with that file will be saved too.
 
 ### Sending
 
 To send objects to Speckle, you'll first need to specify which objects are to be sent.
 This can be done in two ways:
 
-* The simpler way involves manually selecting elements in Microstation, OpenRoads, OpenRail, or OpenBuildings. 
-* The more powerful way is to use filtering logic to select elements.
+- The simpler way involves manually selecting elements in Microstation, OpenRoads, OpenRail, or OpenBuildings.
+- The more powerful way is to use filtering logic to select elements.
 
 For the simpler selection method, follow the steps below:
 
-1. First, ensure the stream you want to send data to is in _Sender_ mode.
+1. First, ensure the project you want to send data to is in _Sender_ mode.
 2. Select the objects you want to send, and left-click the button that says `0 objects` in the Speckle Panel. A drop-down will appear; choose `Set Selection`.
 3. The same button should now display the total count of objects that were selected.
 4. You're ready to send! Press the `Send` button. You should see a progress bar and, once completed, a success message.
@@ -53,13 +51,13 @@ All geometric elements are organized by `Level` when they are sent to Speckle: e
 
 ### Receiving
 
-In order to receive data from a Speckle stream, you'll first need to add that stream to your Speckle streams panel. If the stream already exists on the server it will automatically be added in _Receiver_ mode.
+In order to receive data from a Speckle, you'll first need to create a project to your Speckle projects panel. If the project already exists on the server it will automatically be added in _Receiver_ mode.
 
-Once the stream has been added, go ahead and hit the `Receive` button. This will display a progress bar (just like the sending operation) and, if successful, will add the received objects to the current document.
+Once the project has been added, go ahead and hit the `Receive` button. This will display a progress bar (just like the sending operation) and, if successful, will add the received objects to the current document.
 
 ## Supported Elements
 
-* [Bentley Support Tables](/user/support-tables.html#microstation)
+- [Bentley Support Tables](/user/support-tables.html#microstation)
 
 ## Feedback
 

--- a/user/blender.md
+++ b/user/blender.md
@@ -24,7 +24,7 @@ Once Enabled, a restart of blender may be required.
 
 > Feel free to reachout to us on the [forums](https://speckle.community/) if you're having any difficulties.
 
-### Manual Installation 
+### Manual Installation
 
 Installation through Speckle Manager is recommended  for most users,
 however, for users looking to install the blender connector on **unsupported platforms or Blender versions**,
@@ -38,32 +38,29 @@ However, you will still need to add your accounts, either through [Speckle Manag
     <img src="./img-blender/manual-installer.png" width="33.33%" alt="Screenshot of speckle-blender releases tab, showing manual installer highlighted in the drop-down menu"/>
 </center>
 
-2. Open Blender, and **navigate to the Add-ons menu**, under `Edit -> Preferences`
-3. Press the `Install` button in the top right, and select the downloaded zip.
-4. Once enabled, a restart of blender may be required.
-
-
+1. Open Blender, and **navigate to the Add-ons menu**, under `Edit -> Preferences`
+2. Press the `Install` button in the top right, and select the downloaded zip.
+3. Once enabled, a restart of blender may be required.
 
 ## User Interface
 
 The Blender Connector lives in the 3D viewport toolbar (N) under the Speckle tab. It contains three main panels:
 
 - **User Panel** for switching between different local accounts.
-- **Streams Panel** for browsing your existing streams, creating new streams, or deleting old streams.
-- **Active Stream Panel** for sending and receiving data to and from Speckle.
+- **Projects Panel** for browsing your existing Projects, creating new projects, or deleting old projects.
+- **Active Project Panel** for sending and receiving data to and from Speckle.
 
 ![panels overview](./img-blender/sidebar-menu.png)
 
-The **Streams Panel** shows a list of your most recent streams, which you can search through by name. You can add new streams with the "+" button, delete streams with the "-" button, and refresh the streams with the refresh button.
+The **Projects Panel** shows a list of your most recent projects, which you can search through by name. You can add new projects with the "+" button, delete projects with the "-" button, and refresh the projects with the refresh button.
 
 ![add by url](./img-blender/add-by-url.png)
 
-From version 2.1.9, you can also add existing streams by their URL. You can use the URL to a stream, a specific branch, or a specific commit. Simply paste it into the popup and the correct account, stream, branch, and commit will get selected for you.
+From version 2.1.9, you can also add existing projects by their URL. You can use the URL to a project, a specific model, or a specific version. Simply paste it into the popup and the correct account, project, model, and version will get selected for you.
 
-The **Active Stream Panel** will show more details about the stream you've selected in the Streams Panel. From here, you can change the active branch and commit. You can also Send and Receive any items you have selected in Blender. Under the Send and Receive buttons, you can use the dropdown menus to select a script to run on all elements during the send / receive process.
+The **Active Project Panel** will show more details about the project you've selected in the Projects Panel. From here, you can change the active model and version. You can also Send and Receive any items you have selected in Blender. Under the Send and Receive buttons, you can use the dropdown menus to select a script to run on all elements during the send / receive process.
 
-At the very bottom of the panel (not pictured), you'll find a button that will open the stream in the [Speckle Web App](/user/web).
-
+At the very bottom of the panel (not pictured), you'll find a button that will open the project in the [Speckle Web App](/user/web).
 
 ## Clean Meshes
 
@@ -83,7 +80,7 @@ Clean Mesh option can be accessed from the dialog that pops up after clicking th
 
 There is currently some limited support for [BlenderBIM](https://blenderbim.org/), though this is intended as an export and does not work coming back. To take advantage of this, simply open an IFC using BlenderBIM then use the Speckle Connector to send to Speckle.
 
-<iframe src="https://speckle.xyz/embed?stream=c51120a7f7&commit=767b7288ee" width=600 height=400 />
+<iframe title="Speckle" src="https://app.speckle.systems/projects/c51120a7f7/models/d57e0b6bc8@767b7288ee#embed=%7B%22isEnabled%22%3Atrue%7D" width="600" height="400" frameborder="0"></iframe>
 
 There are a few things to keep in mind when sending an IFC to Speckle using BlenderBIM:
 
@@ -104,8 +101,6 @@ This allows for customisation of how objects are sent/receiveed. For example
 - Applying blender mesh operations to received geometry,
 - Assigning custom properties to objects,
 - Custom behaviours triggered after receive/before send.
-
-
 
 ### Receive Scripts
 1. From the `Scripting` workspace, create a new python file.
@@ -154,22 +149,21 @@ def execute_for_all(context, objects):
 Send scripts are slightly less featured than receive scripts.
 They are mostly useful for filtering which objects to send, although any 
 
-
 -->
 
 ## Developing/Debugging Locally
 
-
-For developers looking **test WIP branches**, or **develop ontop of/contribute to Speckle Blender**,
+For developers looking **test WIP Models**, or **develop ontop of/contribute to Speckle Blender**,
 this is the recommended development setup for the [speckle-blender](https://github.com/specklesystems/speckle-blender) repository.
 
 ::: tip Pre-requisites
 [Git](https://git-scm.com/), [Poetry](https://python-poetry.org/docs/), and the [Python](https://www.python.org/) version used by the desired Blender version </br>(e.g. Python 3.10 for Blender ≥3.0).
 
 Also recommended: [VSCode](https://code.visualstudio.com/) with the [Blender Development Addon for VSCode](https://marketplace.visualstudio.com/items?itemName=JacquesLucke.blender-development) (allows debugging, and automatically symlinks `scripts/addons`)
-::: 
+:::
 
 1. **Git clone** the [speckle-blender](https://github.com/specklesystems/speckle-blender) and [specklepy](https://github.com/specklesystems/specklepy) repositories into the a folder somewhere on your system.
+
 ```sh
 git clone https://github.com/specklesystems/speckle-blender
 git clone https://github.com/specklesystems/specklepy

--- a/user/concepts-advanced.md
+++ b/user/concepts-advanced.md
@@ -1,10 +1,10 @@
 # Advanced Concepts
 
 Congratulations on being an advanced user of Speckle!
-You've breezed through our git-based walkthrough guide and have arrived at the hard stuff. 
+You've breezed through our git-based walkthrough guide and have arrived at the hard stuff.
 
 A lot of careful thought has gone into planning Speckle v2.0.
-Its architecture has been designed to be modular, swappable and hackable. Nearly every part of Speckle can be disassembled and customised to your heart's content. 
+Its architecture has been designed to be modular, swappable and hackable. Nearly every part of Speckle can be disassembled and customised to your heart's content.
 
 Want to write your own Speckle Connector? We wrote a guide to help you with that!
 Want to run your own Speckle server or embed our Three.js viewer into your Notion document? We've got you covered there, too!
@@ -19,23 +19,24 @@ The `Base` object is probably not something you'll have to deal with directly wh
 
 The `Base` object is the building block of Speckle data. It is a dynamic object that is the "base" of all other Speckle objects. The `Base` and other objects that inherit from it have a combination of pre-defined properties (eg `id`, `speckle_type`, `units`) and dynamic properties which can be added on the fly. Property values can also be other `Base` objects such as a `RevitColumn` containing a `Line` representing its base line.
 
-Sending a collection of Revit elements? Each of those elements is being converted into a Speckle Object equivalent which inherits from Speckle's `Base` class. The commit you just created when sending those elements? That is also a `Base` which contains all the Revit elements nested within it.
+Sending a collection of Revit elements? Each of those elements is being converted into a Speckle object equivalent which inherits from Speckle's `Base` class. The version you just created when sending those elements? That is also a `Base` which contains all the Revit elements nested within it.
 
 A key feature of the `Base` object is **decomposition**. This allows you to flag properties as _detachable_; this means they'll exist outside of the parent `Base` object and can be stored or retrieved separately.
 
 For example, if you have several `Beam` and `Wall` elements that all want to reference the same `Level`. Instead of creating multiple copies of this `Level` and storing it within each of the `Beam` and `Wall` objects, you would instead make the `Level` detachable in the `Beam`s and `Wall`s. This allows all the objects to reference the same `Level`, which now only needs to be stored once.
 
-### How do I use the Base Object? 
+### How do I use the Base object?
 
-When using the connectors to send existing data, you won't really need to think about the `Base` object as all this is taken care of for you behind the scenes. The objects in your model are converted to Speckle `Base` objects and then are nested within a parent `Base` object to create the commit - all when you press the "Send" button.
+When using the connectors to send existing data, you won't really need to think about the `Base` object as all this is taken care of for you behind the scenes. The objects in your model are converted to Speckle `Base` objects and then are nested within a parent `Base` object to create the Version - all when you press the "Send" button.
 
-If you are getting into creating your own `Base` objects, our [The Base Object](/dev/base) section and the [Decomposition API](/dev/decomposition) are a great way to get started.
+If you are getting into creating your own `Base` objects, our [The Base object](/dev/base) section and the [Decomposition API](/dev/decomposition) are a great way to get started.
 
 For further information on the `Base` object, see our [deep dive](https://speckle.community/t/core-2-0-the-base-object/782) on the Speckle community forum.
 
 ## Speckle Kits 🔀
 
-### What are Speckle Kits? 
+### What are Speckle Kits?
+
 We said every part of Speckle is hackable. `Speckle Kits` are probably one of the more accessible hacks we've made possible.
 
 As mentioned previously, Speckle converts all incoming data from various software (Revit, Grasshopper, etc) to its software-agnostic 'Speckle' format. It does this via detailed conversion routines, built to handle each of the support applications' APIs.
@@ -48,12 +49,15 @@ In short - Speckle Kits are custom translators to get data to (and from) Speckle
 :::
 
 ### How do I use Speckle Kits?
+
 For a detailed overview of Speckle Kits, see our developer section, and our [deep dive](https://speckle.community/t/introducing-kits-2-0/710/37) on the Speckle community forum.
 
 ## Transports 💾
 
 ### What are Transports?
-Speckle data is designed to be serialized and stored in a number of ways: perhaps you keep your Speckle data in Excel, an SQL database or a non-relational DB system? We introduced `Transports` to Speckle 2.0 to give you full control over how and where your data is stored.
+
+Speckle data is designed to be serialized and stored in a number of ways: perhaps you keep your Speckle data in Excel, an SQL database or a non-relational DB system? We introduced `Transports` to Speckle to give you full control over how and where your data is stored.
 
 ### How do I use Transports?
+
 For a detailed overview of Transports, see our developer section, and our [deep dive](https://speckle.community/t/core-2-0-transports/919) on the Speckle community forum.

--- a/user/concepts.md
+++ b/user/concepts.md
@@ -2,29 +2,29 @@
 
 This section goes into the details on how your data is sent to and stored in Speckle. Whether you're new to Speckle or just need a refresher, this is a great place to start!
 
-### A Quick Note on Terminology
+## A Quick Note on Terminology
 
 We've tried to keep this guide straightforward, removing technical language unless it's absolutely necessary. It's worth noting that whenever we mention the terms **data**, **objects** or **elements**, we're really referring to the same thing. Speckle is built to handle all kinds of data, whether CAD geometry, BIM elements (geometry + metadata) or pure data (text, numbers, etc).
 
-### Streams, Branches and Commits
+## Projects, Models and Versions
 
-Your Speckle data is organised using a robust and sophisticated collaboration approach that's been adopted universally in software development. To keep things simple, we're using the same concepts and terminology, known as **Streams**, **Branches** and **Commits**.
+Your Speckle data is organised using a robust and sophisticated collaboration approach that's been adopted universally in software development. To keep things simple, we're using the same concepts and terminology, known as **projects**, **models** and **versions**.
 
-To use Speckle you only really need to know what a stream is. Branches and commits are slightly more advanced, but will add a lot of flexibility and control to your future collaborative workflows.
+To use Speckle you only really need to know what a project is. models and versions are slightly more advanced, but will add a lot of flexibility and control to your future collaborative workflows.
 
-## Streams
+## Projects
 
-### What are streams
+### What are Projects?
 
-The main data structure in Speckle is the **stream**.
+The main data structure in Speckle is the **project**.
 
-A stream is simply a collection of data with some additional information to help you manage and retrieve them. Each stream is assigned a `streamId` which uniquely identifies the stream on a server. You can also assign a name and description to help keep track of your streams.
+A project is simply a collection of data with some additional information to help you manage and retrieve them. Each project is assigned a `projectId` which uniquely identifies the project on a server. You can also assign a name and description to help keep track of your projects.
 
-A stream also lets you manage permissions: it has a list of collaborators including an owner and additional reviewers and contributors which the owner has chosen to share the stream with.
+A Project also lets you manage permissions: it has a list of collaborators including an owner and additional reviewers and contributors which the owner has chosen to share the Project with.
 
-### What do streams contain?
+### What do Projects contain?
 
-A stream can contain anything from a handful of objects to a whole building model. You are free to add as much or as little data to a single stream and create as many streams as you'd like. Some examples of what might be contained within a stream are:
+A project can contain anything from a handful of objects to a whole building. You are free to add as much or as little data to a single project and create as many projects as you'd like. Some examples of what might be contained within a project are:
 
 - A layer in a CAD application
 - A set of calculation results
@@ -32,77 +32,76 @@ A stream can contain anything from a handful of objects to a whole building mode
 - A selection of objects from Grasshopper
 - A structural model
 
-A stream also contains further options for managing your data using **branches** and **commits**. Don't worry about these yet - we'll cover them in the following sections.
+A project also contains further options for managing your data using **models** and **versions**. Don't worry about these yet - we'll cover them in the following sections.
 
-### Who can I share streams with?
+### Who can I share Projects with?
 
-Streams can be either Public or Private:;
+Projects can be either Private, Link Shared or Discoverable;
 
-- **Public**: Anyone with the link or `streamId` can view the stream
-- **Private**: People need to be added as _collaborators_ to the stream to access it
+- **Private**: People need to be added to the project team to access it
+- **Link Shared**: Anyone with the link or `projectId` can view the project
+- **Discoverable**: The project may be offered for discovery via UI or API without knowledge of the `projectId` or specific permissions
 
-Anyone invited as a collaborator can have varying levels of access to the stream, depending on which role you assign them:
+Anyone invited as a team member can have one of 3 levels of access to the project, depending on which role you assign them:
 
 - **Owner**: Full access, including deletion rights and editing user permissions.
-- **Contributor**: Can edit the stream's contents (create new branches and commits) but cannot edit stream details (name and description) or manage permissions.
-- **Reviewer**: View-only access to a stream.
+- **Editor**: Can edit the project's contents (create new Models and Versions) but cannot edit project details (name and description) or manage permissions.
+- **Viewer**: View-only access to a project.
 
-### How do I use streams?
+### How do I use Projects?
 
-Streams are the main mechanism by which data is shared between people and applications. For example, you could create a stream in Revit and send that data to your server. Then, any of your colleagues with access to that stream could view the data in the browser or receive the data in Grasshopper, Rhino, Revit, etc.
+Projects are the main mechanism by which data is shared between people and applications. For example, you could create a project in Revit and send that data to your server. Then, any of your colleagues with access to that project could view the data in the browser or receive the data in Grasshopper, Rhino, Revit, etc.
 
-If any of your colleagues have _collaborator_ access, they are also free to make their own changes and send their changes to the stream. You can then receive those changes from the stream in your original model to see the changes reflected.
+If any of your colleagues are a team member with Editor access, they are also free to make their own changes and send their changes to the project. You can then receive those changes from the project in your original model to see the changes reflected.
 
 To see step-by-step guides on how to send your data between various supported applications, check out our [tutorials](https://speckle.systems/tutorials/).
 
-## Branches
+## Models
 
-### What are branches?
+### What are Models?
 
-Branches give you an extra layer of organisation within a stream. Speckle users frequently use branches to carry out parallel studies / design options.
+Models give you an extra layer of organisation within a project. Speckle users frequently use models to carry out parallel studies / design options., define different disciplines, or to separate out different parts of a project that may represent different responsibilities or ownership.
 
-All streams start with a single default branch called `main`. If you would like to "branch" off from this `main` branch and work on multiple different versions of your data in parallel or if you want to segment separate parts of your data from each other, that is where branches come in.
+All projects start with a single default model, if you do not name this it may be referenced as `main`. If you would like to "model" off from this `main` model and work on multiple different versions of your data in parallel or if you want to segment separate parts of your data from each other, that is where Models come in.
 
-![branch menu from the Speckle frontend](https://user-images.githubusercontent.com/7717434/107365334-8dd3a180-6ad4-11eb-8d6f-47bc42b80da4.png)
+![Model menu from the Speckle frontend](https://user-images.githubusercontent.com/7717434/107365334-8dd3a180-6ad4-11eb-8d6f-47bc42b80da4.png)
 
-### How do I use branches?
+### How do I use Models?
 
-You can add as many additional branches to your streams as you would like. Speckle Web App gives you the option of creating new branches and switching between them.
+You can add as many additional models to your projects as you would like. Speckle Web App gives you the option of creating new models and switching between them.
 
-Let's say you have a very large model you want to add to a single stream, but your collaborators from different disciplines don't want to receive the whole model every time. You could split the model up into different branches: `Structural`, `MEP`, `Architecture`.
+Let's say you have a very large design you want to add to a single project, but your collaborators from different disciplines don't want to receive the whole design every time. You could split the design up into different models: `Structural`, `MEP`, `Architecture`.
 
-Or perhaps you have a complex model that encompasses a site with multiple separate buildings. You could still contain the whole model in a single stream, but create a separate branch for each building: `Building A`, `Building B`, `Building C`.
+Or perhaps you have a complex design that encompasses a site with multiple separate buildings. You could still contain the whole design in a single project, but create a separate model for each building: `Building A`, `Building B`, `Building C`.
 
-Maybe you're working on a smaller scale and you would like to present different facade options to the client. The stream could be split into `Option A`, `Option B`, and `Option C` which you could then easily switch between to explore the different options in your next meeting.
+Maybe you're working on a smaller scale and you would like to present different facade options to the client. The project could be split into `Option A`, `Option B`, and `Option C` models which you could then easily switch between to explore the different options in your next meeting.
 
-If you happen to be familiar with `git`, you might be wondering _"Can I also merge the content of a branch into another one?"_. The answer is yes, but currently that can only happen inside one of the AEC software for which we have connectors. The merged data can then be re-sent to an existing or new branch.
+If you happen to be familiar with `git`, you might be wondering _"Can I also merge the content of a model into another one?"_. The answer is yes, but currently that can only happen inside one of the AEC software for which we have connectors or prgammatically using our SDKs. The merged data can then be re-sent to an existing or new model.
 
-## Commits
+## Versions
 
-### What are commits?
+### What are Versions?
 
-Commits are essentially a snapshot of your data - a point in time where you have "committed" your changes. They allow you to track the changes in your stream and easily see who changed what and when. The great thing about commits is that they create a timeline of all the changes your stream goes through and give you the possibility of going back in time, resetting your model to any version - whenever you want!
+Versions are essentially a snapshot of your data - a point in time where you have "published" your changes. They allow you to track the changes in your project models and easily see who changed what and when. The great thing about versions is that they create a timeline of all the changes your project models go through and give you the possibility of going back in time, resetting your model to any version - whenever you want!
 
-Each time you send data to Speckle, you are automatically creating a new commit which contains all the objects in your stream along with additional information such as the time, date, and author of the commit. You can also add an optional _commit message_ which is a short description of what you've changed. Like a stream, each commit is assigned a generated `commitId` which can be used to identify and retrieve it. You can go back in time and look at the history of your stream through the series of commits.
+Each time you send data to Speckle, you are automatically creating a new version which contains all the objects in your project along with additional information such as the time, date, and author of the version. You can also add an optional _version message_ which is a short description of what you've changed. Like a project, each version is assigned a generated `versionId` which can be used to identify and retrieve it. You can go back in time and look at the history of your project through the series of versions.
 
-![Commit Card](https://user-images.githubusercontent.com/51519350/186121617-9f83dc01-89c5-4878-b088-7c3a81d4d75d.png)
+![Version Card](https://user-images.githubusercontent.com/51519350/186121617-9f83dc01-89c5-4878-b088-7c3a81d4d75d.png)
 
 Say goodbye to saving your files as "AM_Project_Design-final", "AM_Project_Design-final-final", "AM_Project_Design-final-final-latest"...!
 
 ::: tip IMPORTANT 🙌
-Please Note: Commits aren't editable, you can change their message but not their content. Sent the wrong data? No problem - simply send the correct data and work from that commit instead.
+Please Note: Versions aren't editable, you can change their message but not their content. Sent the wrong data? No problem - simply send the correct data and work from that version instead.
 :::
 
-### How do I use commits?
+### How do I use Versions?
 
-If you have used a connector and you've sent data to a stream, you've already used them! Each time data is sent to a stream, a commit is created. To help you keep track of the changes in your stream, it is a good idea to add a commit message that succinctly describes what the commit contains. Some of the connectors pre-populate a default commit message for you, but you are still free to write your own to add more detail.
+If you have used a connector and you've sent data to a project, you've already used them! Each time data is sent to a project, a version is created. To help you keep track of the changes in your project, it is a good idea to add a version message that succinctly describes what the version contains. Some of the connectors pre-populate a default version message for you, but you are still free to write your own to add more detail.
 
-When receiving data in a connector, you have the option of either staying synced with the latest commit or receiving a specific commit based on the `commitId`. If you choose to stay on the latest commit, you'll see a notification when someone else has sent new data to the stream. When you see this, you'll be able to use the receive function to get the new commit and update your file.
+When receiving data in a connector, you have the option of either staying synced with the latest version or receiving a specific version based on the `versionId`. If you choose to stay on the latest version, you'll see a notification when someone else has sent new data to the Project. When you see this, you'll be able to use the receive function to get the new version and update your file.
 
 ## What Next?
 
-&nbsp;
-
-For some users, this is their first time hearing about streams, branches and commits. Your head must be spinning!
+For some users, this is their first time hearing about projects, models and versions. Your head must be spinning!
 
 However, some users can't get enough of this and are ready to learn all about some of our more advanced topics. For these users, we've got you covered! See our Advanced Concepts page for more.

--- a/user/connectors.md
+++ b/user/connectors.md
@@ -28,7 +28,7 @@ Our Desktop Connectors are plugins for some of the most popular AEC software, in
 
 ...with more on the way soon!
 
-These Connectors take care of sending and receiving data to your Speckle server, in the form of streams (no need for files or file types!)
+These connectors take care of sending and receiving data to your Speckle server, in the form of projects (no need for files or file types!)
 
 ::: tip 💡 TIP
 
@@ -49,7 +49,7 @@ Every time we make a new release of a connector, with bug fixes and new features
 - the MINOR number is increased with any "substantial" new release, currently we try to ship one every month
 - the PATCH number is increased when we need to release hotfixes to any of our connectors, might happen zero or multiple times during a month
 
-If you are working with multiple Speckle Connectors please ensure their MAJOR and MINOR version is always aligned (for instance Grasshopper Connector v 2.5.0 and Revit Connector at 2.5.2).** This is even more important when having Rhino and Grasshopper or Revit and Dynamo Connectors installed at the same time.**
+If you are working with multiple Speckle connectors please ensure their MAJOR and MINOR version is always aligned (for instance Grasshopper Connector v 2.5.0 and Revit Connector at 2.5.2). **This is even more important when having Rhino and Grasshopper or Revit and Dynamo connectors installed at the same time.**
 
 We might from time to time also make pre-releases of our connectors (see Using [Pre-releases](/user/manager.html#using-beta-versions-of-our-connectors)), these will have a `-something` appended to their names such as `2.5.0-alpha`, `2.7.3-rc1`. these are not fully tested and should be installed at your own risk 😱.
 

--- a/user/csi.md
+++ b/user/csi.md
@@ -29,7 +29,7 @@ If the plugin is not installed properly, you can find the path to the PlugIn in 
 
 ### Receiving in CSI Products
 
-Save the CSI model as a file first before attempting to receive streams into your CSI model.
+Save the CSI model as a file first before attempting to receive projects into your CSI model.
 
 ## User Interface
 
@@ -37,13 +37,13 @@ Save the CSI model as a file first before attempting to receive streams into you
 
 This connector uses our shared Desktop UI2. Read up on general guidelines for usage in the [Desktop UI2 section](https://speckle.community/t/new-desktopui-in-alpha-testing/1851/2).
 
-**Streams are saved to a textfile that will appear in your model folder titled "Speckle". Do not delete this folder.**
+**Projects are saved to a textfile that will appear in your model folder titled "Speckle". Do not delete this folder.**
 
 :::
 
 ### Filters
 
-To help you select which elements will be to sent to Speckle, we've built various filters into our CSI connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your Stream. Section properties and materials defined within the model will always be sent.
+To help you select which elements will be to sent to Speckle, we've built various filters into our CSI connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your Project. Section properties and materials defined within the model will always be sent.
 
 _Please Note: Elements are sent regardless of whether they are visible or if they were created after setting up the filter._
 
@@ -55,7 +55,7 @@ The selection filters will send everything that is selected within the CSI displ
 
 #### Group Filters
 
-You can create predefined groups of geometrical elements within CSI products to send already within the CSI group and select based on those groupings of elements for a more precise stream of elements.
+You can create predefined groups of geometrical elements within CSI products to send already within the CSI group and select based on those groupings of elements.
 
 #### Category Filter
 
@@ -89,7 +89,7 @@ You can send analysis results from ETABS, and the Connector offers a set of filt
 
 ## Updating Elements
 
-The connector does not take care of updating existing elements within the stream. However the CSI products does recognize if coincident elements are generated and will not generate new elements that coincide on top of each other.
+The connector does not take care of updating existing elements within the Project. However the CSI products does recognize if coincident elements are generated and will not generate new elements that coincide on top of each other.
 
 ## Revit & BIM Data to CSI Products
 

--- a/user/excel.md
+++ b/user/excel.md
@@ -53,26 +53,26 @@ Currently, **only accounts on servers managed by us are supported**, this is bec
 
 :::
 
-### Adding Streams
+### Adding Projects
 
-Just click the top left menu > Add stream > click on a stream to add to the document. **The stream will be saved in the document and available whenever you return to it.**
+Just click the top left menu > Add Project > click on a Project to add to the document. **The Project will be saved in the document and available whenever you return to it.**
 
 ![excel-add](https://user-images.githubusercontent.com/2679513/119180828-b4588f80-ba68-11eb-8ac3-0aa8f9d5158f.gif)
 
-By default, streams are added as receivers but you can easily switch them to sender mode.
+By default, Projects are added as receivers but you can easily switch them to sender mode.
 
 ![image](https://user-images.githubusercontent.com/2679513/119181346-61330c80-ba69-11eb-9100-7f1b0f9ec82c.png)
 
 ## Receiving Data
 
-Receiving data in excel is quite different than in other connectors, and this is because we need to "flatten" it so to represent it in a table format. In general, a stream will either contain:
+Receiving data in Excel is quite different than in other connectors, and this is because we need to "flatten" it so to represent it in a table format. In general, a Project will either contain:
 
 - Simple values like numbers, text etc
 - Complex data structures (objects) like a Revit Wall or a Grasshopper Line. Objects are identified by a `{}` symbol.
 
 The Excel connector works best when receiving lists of either simple values or objects of the same type. Lists are identified by a `[]` symbol.
 
-Since a commit can contain a variety of data types, after clicking the **receive button**, you'll have the possibility to expand and select which data inside it to actually pull and write to your Excel file. You don't have to receive an entire commit each time!
+Since a Version can contain a variety of data types, after clicking the **receive button**, you'll have the possibility to expand and select which data inside it to actually pull and write to your Excel file. You don't have to receive an entire Version each time!
 
 ![image-20210521205817594](https://user-images.githubusercontent.com/2679513/119197116-2b991e00-ba7f-11eb-8e70-6d7e962361d5.png)
 
@@ -95,7 +95,7 @@ We recommend receiving lists of objects that have the same underlying data struc
 
 ![image](https://user-images.githubusercontent.com/2679513/119189886-88dba200-ba74-11eb-8066-cd98972a88dd.png)
 
-Nested objects are flattened as well and their properties delimited by a period `.`. See the example below where 10 lines have been streamed from Dynamo to Excel:
+Nested objects are flattened as well and their properties delimited by a period `.`. See the example below where 10 lines have been sent from Dynamo and received in Excel:
 
 ![image](https://user-images.githubusercontent.com/2679513/119195280-4e760300-ba7c-11eb-8601-3ed72a6b0813.png)
 
@@ -135,7 +135,7 @@ Step 1 is to send your schedule from Revit to Speckle using the Speckle Revit co
 
 ![image](./img-excel/revit-schedule.png)
 
-The next step is to receive the commit in excel. There is some preprocessing magic that is done in the background to identify that you are trying to receive a schedule. The result of this preprocessing is that you won't be prompted to filter and receive data as you normally would.
+The next step is to receive the version in Excel. There is some preprocessing magic that is done in the background to identify that you are trying to receive a schedule. The result of this preprocessing is that you won't be prompted to filter and receive data as you normally would.
 
 ![image](./img-excel/receive-schedule.gif)
 

--- a/user/ifc.md
+++ b/user/ifc.md
@@ -1,10 +1,10 @@
 # IFC Import Service
 
-Speckle can now process IFC files and store them in your streams. You can then receive them in other applications and access them from the Speckle API.
+Speckle can now process IFC files and store them in your projects. You can then receive them in other applications and access them from the Speckle API.
 
 > This was made possible thanks to the amazing IFC.js Open Source project! 🙌🏼
 
-Our **Import IFC** service can be found in the Stream page sidebar, right under the `Globals` section:
+Our **Import IFC** service can be found in the project page sidebar, right under the `Globals` section:
 
 ![IFC Import](./img-ifc/ifc-sidebar.png)
 
@@ -18,7 +18,7 @@ To upload new files, just drag and drop the `.ifc` file from your computer into 
 
 ![Drag and drop new file](./img-ifc/drag-drop-new-file.gif)
 
-For each file, you can specify what branch of the stream to upload and save to (by default it will be sent to `main`) by selecting the branch name from the drop-down menu.
+For each file, you can specify what model of the project to upload and save to (by default it will be sent to `main`) by selecting the model name from the drop-down menu.
 
 Once ready, press `Upload` to start the process. The item will then be moved to the `Previous Uploads`.
 
@@ -26,7 +26,7 @@ Once ready, press `Upload` to start the process. The item will then be moved to 
 
 ## Previous Uploads
 
-Here you'll be able to view the list of previously uploaded ifc files in that specific stream.
+Here you'll be able to view the list of previously uploaded ifc files in that specific project.
 
 It will also report the current status of the import operation:
 
@@ -38,11 +38,11 @@ It will also report the current status of the import operation:
 
    ![Error status](./img-ifc/upload-error.png)
 
-3. `View Commit`: the import operation succeeded, and there's a new commit on the selected branch. Click on the button to view it.
+3. `View version`: the import operation succeeded, and there's a new version on the selected model. Click on the button to view it.
 
    ![Success status](./img-ifc/upload-complete.png)
 
-You can also download the original `.ifc` file that was used to create this commit at any point in the future by pressing the `download` icon on the left-hand side of the file name.
+You can also download the original `.ifc` file that was used to create this version at any point in the future by pressing the `download` icon on the left-hand side of the file name.
 
 ![Download link](./img-ifc/upload-download.png)
 
@@ -50,4 +50,4 @@ You can also download the original `.ifc` file that was used to create this comm
 
 The result will be available directly in the 3D viewer, and can be received in other applications. Here's a quick example:
 
-<iframe src="https://speckle.xyz/embed?stream=d9f76faff3&commit=3e47b02175" width=600 height=400 />
+<iframe title="Speckle" src="https://app.speckle.systems/projects/d9f76faff3/models/b6184a11b9@3e47b02175#embed=%7B%22isEnabled%22%3Atrue%7D" width="600" height="400" frameborder="0"></iframe>

--- a/user/installing.md
+++ b/user/installing.md
@@ -4,7 +4,7 @@ Manager for Speckle is the best way to get (almost) all our Connectors installed
 
 ::: tip 🙌 IMPORTANT
 This guide assumes you have a **Speckle Account**.
-If you don't, just register on our [free XYZ Speckle server](https://speckle.xyz).
+If you don't, just register on our [General Availability Speckle server](https://app.speckle.systems).
 :::
 
 ## Download

--- a/user/mapping-tool.md
+++ b/user/mapping-tool.md
@@ -24,7 +24,7 @@ See below the required steps for a Rhino > Revit workflow.
 In Revit create or open a document with all the levels, families and types that you're planning to use.
 Then send to Speckle only its levels, families and types.
 
-We recommend using a branch for this, and updating it over time as you add more levels and types.
+We recommend using a model for this, and updating it over time as you add more levels and types.
 
 ![image](https://user-images.githubusercontent.com/2679513/203250688-83d4cf52-d800-41be-b217-ac45cace6a9f.png)
 
@@ -34,7 +34,7 @@ In Rhino, type the `SpeckleMappings` command, this will open up a new panel (Win
 
 ![image](https://user-images.githubusercontent.com/2679513/203253776-f7899083-5e94-4264-8840-f4941f4b32e1.png)
 
-Click on `Select Mapping Source` and select the stream and branch with the Revit data we just sent:
+Click on `Select Mapping Source` and select the project and model with the Revit data we just sent:
 
 ![select-mapping-source](https://user-images.githubusercontent.com/2679513/203254063-5cf9e507-ee22-4969-8613-696bb84b3f49.gif)
 

--- a/user/powerbi-visual/basic-usage.md
+++ b/user/powerbi-visual/basic-usage.md
@@ -6,16 +6,16 @@ title: Basic Usage
 
 The 3D Viewer Visual was designed to work alongside our **Power BI Connector.** The *data connector* will output a table containing the following columns:
 
-- **Stream URL 👈**
+- **Model URL 👈**
 - **URL Type**
-- **Commit Object ID🆕 👈**
+- **Version Object ID🆕 👈**
 - **Object ID 👈**
 - **speckle_type**
 - **data**
 
 ![Visual Columns.png](./img-powerbi-visual/9-visual-columns.png)
 
-**Stream URL**, **Commit Object ID,** and **Object ID** are used to visualize your Speckle data in 3D.
+**Model URL**, **Version Object ID,** and **Object ID** are used to visualize your Speckle data in 3D.
 
 ## Viewing Objects in 3D
 
@@ -23,8 +23,8 @@ The 3D Viewer Visual was designed to work alongside our **Power BI Connector.**
 
 With the Speckle 3D Viewer Visual added, you can now configure the input fields to display your Speckle data.
 
-1. Drag the "**Stream URL**" column from your data into the "`Stream URL`" input field.
-2. Drag the "**Commit Object ID**" column from your data into the "`Commit Object ID`" input field.
+1. Drag the "**Model URL**" column from your data into the "`Model URL`" input field.
+2. Drag the "**Version Object ID**" column from your data into the "`Version Object ID`" input field.
 3. Drag the "**Object ID**" column from your data into the "`Object ID`" input field.
 
 Once all inputs are added, 3D Viewer Visual will load the objects into the scene.
@@ -36,7 +36,7 @@ There are two extra optional fields:
 
 :::tip 📌IMPORTANT
 
-The `Stream URL`, `Commit Object ID`, and `Object ID` columns will exist on the resulting query when using the `Get by URL` function.
+The `Model URL`, `Version Object ID`, and `Object ID` columns will exist on the resulting query when using the `Get by URL` function.
 
 If you're using the new (experimental) `Get by URL [Structured]` function, you must generate these columns in your final query table. The information is attached to the table as a `META` that can be queried in your Query Editor.
 :::

--- a/user/powerbi/accessing-private-streams.md
+++ b/user/powerbi/accessing-private-streams.md
@@ -1,6 +1,6 @@
-# Accessing Private Streams
+# Accessing Private Models
 
-Once you complete the installation and configuration steps, you can receive “public” streams from Speckle. To receive your private streams, you need to complete authentication. There are two authentication methods:
+Once you complete the installation and configuration steps, you can receive “public” models from Speckle. To receive your private models, you need to complete authentication. There are two authentication methods:
 
 - Log in using your Speckle Account.
 - With a Personal Access Token.
@@ -14,7 +14,7 @@ You can now log in with **any account of any Speckle server**. Here’s how you
   Your browser does not support the video tag.
 </video>
 
-1. First, paste the URL of Private Stream you want to receive and click “OK”.
+1. First, paste the URL of Private Model you want to receive and click “OK”.
 2. Select the ”Server URL” option in the credentials pop-up. In our case, it is “**Speckle.xyz**”.
 3. Then press the ”**Sign in”** button. This will open a pop-up window prompting you to log into your account and allow the Power BI app to access your user data. This grants `read-only` access, as recommended by Power BI guidelines.
 
@@ -35,11 +35,11 @@ Another way of authenticating is with a “Personal Access Token”. Tokens are 
 4. This will create a token for you. Make sure you copy it. It is the first and last time you’ll be able to see this token. Treat it as a _Password,_ and do not share it with anyone.
 5. Go to **Power BI > Options and Settings > Data source settings.**
 6. Go to **Global Permissions** and select your Speckle server.
-7. After selecting a server, follow **Edit Permissions > Edit > Private Stream.** Paste your *Token* into `Personal Access Token` input.
+7. After selecting a server, follow **Edit Permissions > Edit > Private Model.** Paste your *Token* into `Personal Access Token` input.
 
 That’s it! Now, Power BI will continue fetching your private data from the Speckle server.
 
 :::tip 📌IMPORTANT
-Delete existing servers if you have trouble seeing your server under Data sources. Return to the Speckle Connector and try to receive the same stream/branch/commit. You’ll have the option to add it from there.
+Delete existing servers if you have trouble seeing your server under Data sources. Return to the Speckle Connector and try to receive the same model/version. You’ll have the option to add it from there.
 
 :::

--- a/user/powerbi/introduction.md
+++ b/user/powerbi/introduction.md
@@ -26,9 +26,8 @@ Currently, Speckle Connector for Power BI supports **Power BI Desktop only**.
 
 ## Features
 
-Power BI connector allows you to import your Speckle Stream, Branch, Commit, or Object data using the corresponding URL. The following data will be retrieved depending on which type of URL you use:
+Power BI connector allows you to import your Speckle Model, Version, or Object data using the corresponding URL. The following data will be retrieved depending on which type of URL you use:
 
-- **Stream URL** -> the most recent commit on the main branch of this stream
-- **Branch URL** -> the most recent commit on this branch
-- **Commit URL** -> this commit
+- **Model URL** -> the most recent version on this model
+- **Version URL** -> this version
 - **Object URL** -> this object

--- a/user/powerbi/using-powerbi-connector.md
+++ b/user/powerbi/using-powerbi-connector.md
@@ -6,14 +6,14 @@ Once the connector is installed, you'll find two new options in the ”**Get Da
 
 <img class="rounded-dropshadow" src="./img-powerbi/4-receive-methods.png" alt="Receive Methods">
 
-1.  **`Speckle - Get Stream by URL (beta)`** (Recommended option for beginners)
-2.  **`Speckle - Get Stream by URL [Structured] (beta)`** (experimental).
+1.  **`Speckle - Get Model by URL (beta)`** (Recommended option for beginners)
+2.  **`Speckle - Get Model by URL [Structured] (beta)`** (experimental).
 
-### Speckle - Get Stream by URL (beta)
+### Speckle - Get Model by URL (beta)
 
 This is recommended if you are just starting with the Speckle Power BI connector.
 
-Using it is simple: paste **Stream/Branch/Commit URL** and click **OK**.
+Using it is simple: paste **Model/Version URL** and click **OK**.
 
 <img class="rounded-dropshadow" src="./img-powerbi/5-default-method.gif">
 
@@ -21,9 +21,9 @@ The result of that query will be a table with the following columns:
 
 ![Received Data](./img-powerbi/6-received-data-columns.png)
 
-1. **Stream URL**: This is the URL of your stream.
-2. **URL Type**: Type or category of the input URL. Its value can be Stream, Branch, Commit, or Object.
-3. **Commit Object ID🆕:** The ID of the root object each individual object came from. For streams/branches/commits, it will be the referenced commit object. For object URLs, it will match the object id on the URL.
+1. **Model URL**: This is the URL of your model.
+2. **URL Type**: Type or category of the input URL. Its value can be Model, Version, or Object.
+3. **Version Object ID🆕:** The ID of the root object each individual object came from. For model/versions, it will be the referenced version object. For object URLs, it will match the object id on the URL.
 4. **Object ID**: The ID of each speckle object in the table. This was extracted from the `data` records.
 5. **speckle_type:** Speckle Type of each object.
 6. **data**: A column of records containing the data belonging to each speckle object.
@@ -31,7 +31,7 @@ The result of that query will be a table with the following columns:
 Other columns may be present and can be user-generated but are irrelevant to this section.\*\*\*\*
 
 :::tip 📌IMPORTANT
-Stream URL, Commit Object ID and Object ID were added to facilitate loading data into the new Speckle Power BI 3D Viewer
+Model URL, Version Object ID and Object ID were added to facilitate loading data into the new Speckle Power BI 3D Viewer
 :::
 
 #### Data Column
@@ -42,7 +42,7 @@ If you look at the values of the data column, you’d see it is full of Records.
 
 In the case of Speckle, where objects are essentially JSON objects with key-value pairs, these objects are converted into Record objects in Power BI when received. This conversion enables the representation of the complex data structures from Speckle as Records within Power BI.
 
-### Speckle - Get Stream by URL [Structured] \(beta\)
+### Speckle - Get Model by URL [Structured] \(beta\)
 
 :::warning ⚠️WARNING
 This feature is experimental and may change in future releases.

--- a/user/qgis.md
+++ b/user/qgis.md
@@ -37,32 +37,36 @@ You can also install the plugin from Speckle Desktop Manager:
 
 Once the plugin is installed, you'll find a new toolbar button in QGIS that will open the `SpeckleQGIS` panel. The panel contains a very simple interface:
 
+
 ![Plugin view](./img-qgis/03_open_plugin.png)
 
-#### Adding a stream to the project
+#### Adding a Speckle project to the QGIS project
 
-First, you need to search and add a stream to the QGIS project. For that, you can press the Search button near the `Stream` panel. This will open a new pop-up window that will allow you to search for a specific stream and add it to QGIS project.
+First, you need to search and add a project to the QGIS project. For that, you can press the Search button near the `Project` panel. This will open a new pop-up window that will allow you to search for a specific project and add it to QGIS project.
 
-![Search stream panel](./img-qgis/add_stream_img.png)
 
-From the list of streams in the dropdown list, you can select one to make it the **current active stream**. This will be the stream used for sending/receiving data. When an active stream is selected, the `Branch` dropdown will be populated with all available branches from that stream.
+![Search project panel](./img-qgis/add_stream_img.png)
+
+
+From the list of projects in the dropdown list, you can select one to make it the **current active project**. This will be the project used for sending/receiving data. When an active project is selected, the `Model` dropdown will be populated with all available models from that project.
 
 And here's a short gif of the process 👇🏼
 
-![Adding a stream to the project](./img-qgis/add_stream_gif.gif)
+![Adding a project to the QGIS project](./img-qgis/add_stream_gif.gif)
 
-> Once a stream is added to the QGIS project, it is saved along with it so the streams will still be available after restarting QGIS.
+> Once a project is added to the QGIS project, it is saved along with it so the projects will still be available after restarting QGIS.
+
 
 #### Sending data
 
 In order to send your data, just follow these steps:
 
-1. Select a stream from the dropdown list.
-2. Specify a specific branch to send data to using the dropdown menu.
+1. Select a project from the dropdown list.
+2. Specify a specific model to send data to using the dropdown menu.
 3. Select the layers in the file that you wish to send.
-4. (optional) Write a commit message.
+4. (optional) Write a version message.
 5. (optional) If you want to receive it in a non-GIS software or view in the browser, make sure you set your project to CRS of projected type (e.g. using Meters as units).
-5. Send the data.
+6. Send the data.
 
 The geometry will be reprojected and sent in a `Project CRS` of your QGIS project (shown in the bottom right corner in QGIS panel). If the chosen Coordinate Reference System is of Geographic type with non-linear units, they will be treated as Meters in other software that do not support such units.
 
@@ -84,10 +88,10 @@ Once data has been sent to Speckle, you can view the result by going to your Spe
 
 Steps to receive the data:
 
-1. Select the stream to receive data from
-2. Select the branch
-3. Select specific commit (by default the latest one)
-4. Find the received layers in the new layer group named after stream, branch and commit
+1. Select the project to receive data from
+2. Select the model
+3. Select specific version (by default the latest one)
+4. Find the received layers in the new layer group named after project, model and version
 
 ![Receiving data](./img-qgis/receive.gif)
 

--- a/user/quickstart.md
+++ b/user/quickstart.md
@@ -6,12 +6,12 @@ Pressed for time? Here's a lightning-fast intro to getting started!
 
 Before you can use Speckle, you'll need an account!
 
-- You can register on our [free official XYZ Server](https://speckle.xyz/))
+- You can register on our [General Availability Server](https://app.speckle.systems/))
 - Otherwise, If your company runs its own Speckle server, you can register using the URL they provided
 
 As you register, a friendly onboarding wizard will take you through some set-up steps.
 
-## Creating your first stream
+## Creating your first project
 
 ![image](https://user-images.githubusercontent.com/2679513/148923228-790246ff-d25a-4c25-966c-e2399b2ea13e.png)
 
@@ -19,15 +19,15 @@ Congratulations 🥳! You now have a Speckle account and have logged in, what yo
 
 From here, you can view and manage data and 3D models you have sent to Speckle or that others have shared with you.
 
-**Let's now create your first stream:** to do so click on the big blue button that says "New Stream".
+**Let's now create your first project:** to do so click on the big blue button that says "+ New".
 
-:::tip 💡 What's a Stream
+:::tip 💡 What's a project
 
-**Streams** are collections of data inside Speckle. You can see a stream as a folder, a project or a repository.
+**Projects** are collections of data inside Speckle. You can see a project as a folder or a repository.
 
-Data in a stream is stored in **commits**, which are snapshots of data in time. Every time you send to Speckle from a connector, a commit is created.
+Data in a project is stored in **versions**, which are snapshots of data in time. Every time you send to Speckle from a connector, a version is created.
 
-Commits can also be organized in **branches**, for instance, to have multiple design options or to store data by discipline. The default branch is called main.
+Versions can also be organized in **models**, for instance, to have multiple design options or to store data by discipline. The default model if there is no name set is called "main".
 
 :::
 
@@ -35,7 +35,7 @@ Commits can also be organized in **branches**, for instance, to have multiple de
 
 ## Sending and Receiving data with Connectors
 
-New Streams are always empty, in order to get data into them we'll need to use one of the many Speckle connectors
+New projects are always empty, in order to get data into them we'll need to use one of the many Speckle connectors
 
 :::tip 💡 What are Connectors
 
@@ -67,7 +67,7 @@ In order to use use our connector, you also need to log into your Speckle accoun
 
 The connectors for [Grasshopper](/user/grasshopper) and [Dynamo](/user/dynamo) are fairly aligned. The most important components/nodes are `Send Data` and `Receive Data`. These connectors will use the default account you've set in Speckle Manager, though this can be overridden using the relevant `Account` components/nodes.
 
-You also get components/nodes to `Create`, `Get`, `Update`, and `Delete` streams as well as get a `List` of your streams or more `Details` for a stream. Streams can be retrieved by either using the `List` component or the URL of a specific stream, branch, commit or object.
+You also get components/nodes to `Create`, `Get`, `Update`, and `Delete` projects as well as get a `List` of your projects or more `Details` for a project. Projects can be retrieved by either using the `List` component or the URL of a specific project, model, version or object.
 
 Finally, there are some more advanced components/nodes for creating and expanding custom objects, for JSON serialisation, and local sending / receiving.
 
@@ -77,17 +77,17 @@ Finally, there are some more advanced components/nodes for creating and expandin
 
 Most other Connectors share the same user interface, you can read more about it [in its own section](/user/ui2).
 
-From it, you can select a Stream you have previously created and decide whether to send or receive data from it. Pretty simple huh?!
+From it, you can select a project you have previously created and decide whether to send or receive data from it. Pretty simple huh?!
 In case you were wondering what data exchanges are allowed between all the various supported software, we have created a series of [Supported Elements tables](/user/support-tables) that will help you.
 
 ![dui2-select](https://user-images.githubusercontent.com/2679513/139484851-8038b1c3-e0a5-4585-892e-bc870974f422.gif)
 
 ## Seeing your models online
 
-After you've sent something to Speckle (aka you created a commit, using Speckle's lingo) you'll be able to see it in our 3D viewer and embed it into almost any other web page.
-Just head to that stream in our web app to do so!
+After you've sent something to Speckle (aka you created a version, using Speckle's lingo) you'll be able to see it in our 3D viewer and embed it into almost any other web page.
+Just head to that project in our web app to do so!
 
-Here's a sample one we have created for you: [https://speckle.xyz/streams/3073b96e86](https://speckle.xyz/streams/3073b96e86)
+Here's a sample one we have created for you: [https://app.speckle.systems/projects/3073b96e86](https://app.speckle.systems/projects/3073b96e86)
 
 Once your data is on Speckle, there's of course much more you can do like:
 

--- a/user/revit.md
+++ b/user/revit.md
@@ -29,7 +29,7 @@ This connector uses our shared Desktop UI. Read up on general guidelines for usa
 
 ### Selection Filters
 
-To help you select which elements will be to sent to Speckle, we've built various filters into our Revit connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your Stream.
+To help you select which elements will be to sent to Speckle, we've built various filters into our Revit connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your project.
 
 _Please Note: Elements are sent regardless of whether they are visible or if they were created after setting up the filter._
 
@@ -73,7 +73,7 @@ To access the Filters feature, follow these steps:
 
 ### Receive Modes
 
-When receiving from a Stream that has been received before, you might want to update, create or ignore elements that were already created before.
+When receiving from a project that has been received before, you might want to update, create or ignore elements that were already created before.
 This is when the **Receive Mode** setting comes in! This is how it works:
 
 - update: updates elements if they already exist and creates missing ones (current behavior in Revit)
@@ -129,13 +129,13 @@ The connector takes care of updating received elements automatically where possi
 Elements are updated under these two circumstances:
 
 - If the element was created in another project/software and had been received previously: for example, BuiltElements that were created in Rhino or Grasshopper
-- If the element was created in the same project you're working on: for example, if you send some walls to Speckle, edit them, and receive them again from the same stream
+- If the element was created in the same project you're working on: for example, if you send some walls to Speckle, edit them, and receive them again from the same project
 
 Here are some technical details if you're curious about what's happening behind the scenes:
 
 - BuiltElements have a property called `applicationId`, this is different from the `id/hash` property on them, and represents the id of such element in the host application in which it was first created. If the element was created in Revit it’s the `UniqueId`, if coming from Grasshopper/Rhino an analogous field
-- When a stream is received in Revit the `applicationIds` of all BuiltElements created are cached in the receiver
-- When receiving a second time from the same stream, if the received elements have the same `applicationId` of something that was previously received (and it still exists in the document), the connector will attempt to modify them instead of creating new ones. If the update fails (or is not permitted by the API), it’ll delete them and create new ones
+- When a project is received in Revit the `applicationIds` of all BuiltElements created are cached in the receiver
+- When receiving a second time from the same project, if the received elements have the same `applicationId` of something that was previously received (and it still exists in the document), the connector will attempt to modify them instead of creating new ones. If the update fails (or is not permitted by the API), it’ll delete them and create new ones
 - If no cached element is found, but there is an element in the document with a matching `applicationId` that is used for the update (this is the case of someone restoring changes previously sent, in the same project)
 - If an element being received doesn’t have an `applicationId` no update mechanism will happen (this could be the case of BuiltElements created in Python if no `applicationIds` are generated manually)
 
@@ -173,9 +173,9 @@ To easily explore on object's data and parameters, our [Speckle Web App](/user/w
 
 ![web-bim-data](https://user-images.githubusercontent.com/51519350/186416982-15eb496a-18fc-4782-b1d2-a6df01e9a5ed.png)
 
-## Stream Advanced Settings
+## Project Advanced Settings
 
-The `Advanced Settings` page allows you to customize the way Speckle behaves "per-stream".
+The `Advanced Settings` page allows you to customize the way Speckle behaves "per-project".
 
 ![Advanced settings page](./img-revit/revit-advancedSettings-view.png)
 
@@ -222,14 +222,15 @@ Availible options are:
 - Never
   Speckle will do all the mapping for you.
 - Always
-  Everytime a Speckle commit is received, you will see a table of all the incoming object types and get the chance to set a mapped native Revit type to each incoming type.
+    
+    Everytime a Speckle version is received, you will see a table of all the incoming object types and get the chance to set a mapped native Revit type to each incoming type.
 - For New Types
+    
+    When a project is first received, you will see a table of all incoming types and map them to types in the Revit application (exactly the same as the above option). 
 
-  When a stream is first received, you will see a table of all incoming types and map them to types in the Revit application (exactly the same as the above option).
-
-  When you receive from the same stream a second time, however, the mapping dialog will only appear if there are new incoming types that have not previously been mapped by the user.
-
-  If the next commit received contains the same objects as the first commit, then the previous custom mapping will be used and you will not be asked to remap all of the incoming types.
+    When you receive from the same project a second time, however, the mapping dialog will only appear if there are new incoming types that have not previously been mapped by the user. 
+    
+    If the next version received contains the same objects as the first version, then the previous custom mapping will be used and you will not be asked to remap all of the incoming types.
 
 #### Import types
 
@@ -270,7 +271,7 @@ Make sure to select the filter you intent to use when the scheduler is triggered
 
 ![image](https://user-images.githubusercontent.com/2679513/159046830-a40b6dc0-46f1-4681-9de1-fb094c8d41ff.png)
 
-Now that your sender stream is saved you can open the Scheduler and select it, together with the intended trigger:
+Now that your sender project is saved you can open the Scheduler and select it, together with the intended trigger:
 
 ![image](https://user-images.githubusercontent.com/2679513/159047256-1971295a-782e-439e-be61-c92d712ae1fd.png)
 

--- a/user/revit/features.md
+++ b/user/revit/features.md
@@ -52,13 +52,13 @@ The connector takes care of updating received elements automatically where possi
 **Elements are updated under these two circumstances:**
 
 - If the element was created in another project/software and had been received previously: for example, BuiltElements that were created in Rhino or Grasshopper.
-- If the element was created in the same project you're working on: for example, if you send some walls to Speckle, edit them, and receive them again from the same stream
+- If the element was created in the same project you're working on: for example, if you send some walls to Speckle, edit them, and receive them again from the same model
 
 Here are some technical details if you're curious about what's happening behind the scenes:
 
 - BuiltElements have a property called `applicationId`, this is different from the `id/hash` property on them, and represents the id of such element in the host application in which it was first created. If the element was created in Revit it’s the `UniqueId`, if coming from Grasshopper/Rhino an analogous field
-- When a stream is received in Revit the `applicationIds` of all BuiltElements created are cached in the receiver
-- When receiving a second time from the same stream, if the received elements have the same `applicationId` of something that was previously received (and it still exists in the document), the connector will attempt to modify them instead of creating new ones. If the update fails (or is not permitted by the API), it’ll delete them and create new ones
+- When a model is received in Revit the `applicationIds` of all BuiltElements created are cached in the receiver
+- When receiving a second time from the same model, if the received elements have the same `applicationId` of something that was previously received (and it still exists in the document), the connector will attempt to modify them instead of creating new ones. If the update fails (or is not permitted by the API), it’ll delete them and create new ones
 - If no cached element is found, but there is an element in the document with a matching `applicationId` that is used for the update (this is the case of someone restoring changes previously sent, in the same project)
 - If an element being received doesn’t have an `applicationId` no update mechanism will happen (this could be the case of BuiltElements created in Python if no `applicationIds` are generated manually)
 

--- a/user/revit/sending-models.md
+++ b/user/revit/sending-models.md
@@ -52,7 +52,7 @@ Before sending data from Revit, it is important to determine where you want to s
 
 To create a Speckle Project:
 
-1. Click the **Create New Stream(Project)** button.
+1. Click the **Create New Project** button.
 2. Provide a **Name** for your Project and an optional **Description**.
 3. Use the toggle, to make your project **Private** or **Link Shareable**.
 4. Click **Create**.

--- a/user/rhino.md
+++ b/user/rhino.md
@@ -25,7 +25,7 @@ Once installed, you can find the connector by running the `Speckle` command in R
 
 > This connector uses our shared Desktop UI. Read up on general guidelines for usage in the [Desktop UI section](/user/ui).
 
-Once the Desktop UI panel is open, go ahead and create a new stream (or add an existing one) to the current file. Once the Rhino `.3dm` file is saved, the streams associated with that file will be saved too.
+Once the Desktop UI panel is open, go ahead and create a new project (or add an existing one) to the current file. Once the Rhino `.3dm` file is saved, the projects associated with that file will be saved too.
 
 ### Sending
 
@@ -35,7 +35,7 @@ Sending objects to Speckle can be done in multiple ways.
   ![Rhino_l5U9dlMIpg](https://user-images.githubusercontent.com/51519350/187154289-8bbb5ff6-8e86-4adc-bd16-110025e2b78a.gif)
 - `Layers` option will send objects on the selected layers.
   ![Rhino_Sv9ZFfjPtS](https://user-images.githubusercontent.com/51519350/187154488-db2a5a2c-ee20-46cc-b115-5bd5c4732622.gif)
-- `Project Information` adds the selected project information as views to the stream.
+- `Project Information` adds the selected project information as views to the project.
   ![Rhino_geo27Qb21a](https://user-images.githubusercontent.com/51519350/187154964-a3d05c4d-2f94-4133-8aac-691d62cf8674.gif)
 - `Selection` sends only the selected objects.
   ![Rhino_e9hP9XMEgx](https://user-images.githubusercontent.com/51519350/187155192-2c85a908-ffba-4e14-8d46-ec4653a92c00.gif)
@@ -44,21 +44,21 @@ For the detail-lovers out there, you'll notice that your Rhino layer structure i
 
 ### Receiving
 
-In order to receive data from a Speckle stream, you'll first need to add that to your active document. If the stream already exists on the server it will automatically be listed. You can also use the search bar to find the stream you are looking for👀.
+In order to receive data from a Speckle project, you'll first need to add that to your active document. If the preoject already exists on the server it will automatically be listed. You can also use the search bar to find the project you are looking for👀.
 
-![rhino-search-stream](https://user-images.githubusercontent.com/51519350/187166411-6759734d-6335-4134-92ad-06010d1af36f.png)
+![rhino-search-project](https://user-images.githubusercontent.com/51519350/187166411-6759734d-6335-4134-92ad-06010d1af36f.png)
 
-Once the stream has been added, switch to the `Receive` mode.
+Once the project has been added, switch to the `Receive` mode.
 
 ![Rhino_zbpyw7DbW5](https://user-images.githubusercontent.com/51519350/187166530-974e37fb-dcc4-48a0-a739-6a134cc94e4f.gif)
 
-From here, you can select the `branch` and the `commit` you want to receive. Once you are done with the selection, go ahead and click on the `🔵 Receive` button. This will display a progress bar (just like the sending operation) and, if successful, will add the received objects to the current document.
+From here, you can select the `model` and the `version` you want to receive. Once you are done with the selection, go ahead and click on the `🔵 Receive` button. This will display a progress bar (just like the sending operation) and, if successful, will add the received objects to the current document.
 
 ![Rhino_R2Ga18NETv](https://user-images.githubusercontent.com/51519350/187166647-a18dd449-faff-4806-a4c4-e59b8a6c57a7.gif)
 
-In order to prevent overriding existing layers/objects in the file, all received objects will be placed in a nested layer structure. This structure will contain all the layers. that the sent objects were placed to, with a parent layer with a name in the format `<STREAM_NAME>: <BRANCH_NAME> @ <COMMIT>`.
+In order to prevent overriding existing layers/objects in the file, all received objects will be placed in a nested layer structure. This structure will contain all the layers. that the sent objects were placed to, with a parent layer with a name in the format `<PROJECT_NAME>: <MODEL_NAME> @ <VERSION>`.
 
-![Commit layers](./img-rhino/rhino-stream-receive-nested-layers.png)
+![Version layers](./img-rhino/rhino-stream-receive-nested-layers.png)
 
 In the screenshot above, you can see the difference between:
 
@@ -96,12 +96,12 @@ If this is your first time installing the Speckle connector, you may need to loa
 Assigning or removing Speckle BIM tags from geometry objects is easy:
 
 1. Select the geometry you would like to map to a BIM element
-2. (Optional) Click `Choose Stream` to select the branch of the Speckle stream that contains your Revit families and levels. If none is selected, a default mapping will be used if available.
+2. (Optional) Click `Choose project` to select the model of the Speckle project that contains your Revit families and levels. If none is selected, a default mapping will be used if available.
 3. Click `Apply Mappings`
 
 ![ui](./img-rhino/BIM/ui.png)
 
-Rhino Mapper manages BIM mappings by assigning geometry objects a `Attribute User Text` property if they have been flagged as BIM elements while sending to a stream. You can see which objects in your model have been mapped at the bottom of the Speckle Mapper UI.
+Rhino Mapper manages BIM mappings by assigning geometry objects a `Attribute User Text` property if they have been flagged as BIM elements while sending to a project. You can see which objects in your model have been mapped at the bottom of the Speckle Mapper UI.
 
 To remove a mapping, click the checkbox next to the existing mapping and then click `Clear Mappings`.
 

--- a/user/sketchup.md
+++ b/user/sketchup.md
@@ -1,0 +1,93 @@
+# SketchUp (Alpha) 🛠️
+
+::: tip IMPORTANT ⚠️
+This connector is currently in alpha with limited functionality - please keep this in mind while testing!
+:::
+
+![example-send](./img-sketchup/sketchup-hostel-sent.png)
+
+## Getting Started
+
+Before using this connector, you'll need to follow our standard setup instructions to [install Speckle Manager and add a Speckle account](/user/manager).
+
+As this connector is still in heavy development, see the [repo](https://github.com/specklesystems/speckle-sketchup) for the latest updates.
+
+## Installation
+
+The easiest way to install the SketchUp Alpha Connector is via the [Speckle Manager](/user/manager). Simply open up manager, find the SketchUp connector, and click "Install".
+
+However, this method only works for Windows for SketchUp 2021. If you'd like to try installing on a different platform or for a different version, you can do a manual installation. Note that the connector has been developed for SketchUp 2021 and has not been tested on older versions or on different platforms. There may be issues, so feel free to report them on the [forum](https://speckle.community/).
+
+### Manual Installation 
+
+#### 1. Clone the repository
+
+First, ensure you have [git](https://git-scm.com/downloads) installed.
+
+Run the following command in your terminal to clone the repo:
+
+    git clone https://github.com/specklesystems/speckle-sketchup
+
+This will create a `speckle-sketchup` folder with the connector files wherever you run this command.
+
+#### 2. Build the User Interface
+
+Navigate into the `ui/` folder
+
+    cd speckle-sketchup/ui
+
+Then run the following commands
+
+    npm install
+    npm run build
+
+This will create a `html` folder inside the `speckle-sketchup/speckle_connector` folder.
+
+
+#### 3. Add the Connector to SketchUp
+
+Find the `Plugins` folder for your SketchUp installation. On Windows for SketchUp 2021, the folder will be at:
+
+    C:\Users\{YOU}\AppData\Roaming\SketchUp\SketchUp 2021\SketchUp\Plugins
+
+Once you've found the equivalent for your OS / SketchUp version, copy the `speckle_connector` folder and the `speckle_connector.rb` file into the `Plugins` folder.
+
+## User Interface
+
+### Sending Data
+
+For the moment, there is only one send mode: selection.
+
+Simply select all the objects you would like to send, then click the "Send" cube. To switch the targeted model, click the currently selected model and find the model from the dropdown menu.
+
+![sending-with-sketchup-img](./img-sketchup/sketchup-send.png)
+
+See the gif below for the full process.
+
+![sending-with-sketchup-gif](./img-sketchup/sketchup-send.gif)
+
+### Receiving Data
+
+Receiving projects in SketchUp is as simple as clicking the "Receive" cube. As with sending, you can switch the targeted model and the particular version to receive.
+
+Note that if you sent SketchUp groups to a project, they will be received as component instances rather than groups.
+
+![receiving-with-sketchup-img](./img-sketchup/sketchup-receive.png)
+
+See the full process of receiving a Rhino model in this snazzy gif
+
+![sketchup-receive](https://user-images.githubusercontent.com/7717434/140315797-089bb936-fb3d-4c05-9e4b-687e0835bb68.gif)
+
+
+### Accounts
+
+Your Speckle accounts should be added via [Speckle Manager](/user/manager).
+
+You can switch between your accounts by clicking your profile image and selecting it from the popup menu.
+
+![sketchup-switch-accounts](https://user-images.githubusercontent.com/7717434/140301242-f4b04004-d1f6-4946-8802-dc95d3245746.gif)
+
+
+## Supported Elements
+
+See [SketchUp Support Tables](/user/support-tables.html#sketchup)

--- a/user/sketchup/advanced-settings.md
+++ b/user/sketchup/advanced-settings.md
@@ -39,7 +39,7 @@ Notably, this registration process might slightly increase the conversion time, 
 
 ## 6. Diffing (experimental)
 
-Diffing feature is currently in the experimental phase. When this setting is enabled, a small triangle icon will appear next to the stream card. Clicking on this icon will display the differences between the version you sent to Speckle and the current version in SketchUp.
+Diffing feature is currently in the experimental phase. When this setting is enabled, a small triangle icon will appear next to the project card. Clicking on this icon will display the differences between the version you sent to Speckle and the current version in SketchUp.
 
 ::: warning
 ⚠️ The feature currently shows only the geometries modified with the push-pull tool between the versions.

--- a/user/sketchup/basic-usage.md
+++ b/user/sketchup/basic-usage.md
@@ -19,7 +19,7 @@ To send data:
 
 1. Select all the objects you want to send.
 2. Click on the "**Send**" cube.
-3. If you wish to change the target branch, click on the selected branch and choose the desired branch from the dropdown menu.
+3. If you wish to change the target model, click on the selected model and choose the desired model from the dropdown menu.
 
 ## Receiving Data
 
@@ -28,51 +28,51 @@ To send data:
   Your browser does not support the video tag.
 </video>
 
-Receiving streams in SketchUp is as simple as clicking the "**Receive**" cube. As with sending, you can switch the targeted branch and the particular commit to receive.
+Receiving models in SketchUp is as simple as clicking the "**Receive**" cube. As with sending, you can switch the targeted model and the particular version to receive.
 
 ::: warning
-Note that if you sent SketchUp groups to a stream, they will be received as component instances rather than groups.
+Note that if you sent SketchUp groups to a model, they will be received as component instances rather than groups.
 :::
 
-## Creating a New Stream
+## Creating a New Project
 
 <video autoplay muted loop>
   <source src="./img-sketchup/create-stream.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 
-Creating a new stream is also really easy.
+Creating a new project is also really easy.
 
-1. Click on the "**Create New Stream**" button.
-2. A dialog box will appear. Provide a **name** for your stream and an optional **description**.
-3. To make your stream **private**, use the toggle option.
-4. Click on the "**Create**" button to finalize and create your stream.
+1. Click on the "**Create New Project**" button.
+2. A dialog box will appear. Provide a **name** for your project and an optional **description**.
+3. To make your project **private**, use the toggle option.
+4. Click on the "**Create**" button to finalize and create your project.
 
-That's it! Your new stream is now successfully created.
+That's it! Your new project is now successfully created.
 
-## Creating a Branch
+## Creating a Model
 
 <video autoplay muted loop>
   <source src="./img-sketchup/create-branch.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 
-To create a new branch:
+To create a new model:
 
-1. Hover over the branch button. “**+**” button will appear on the left. Click on it.
-2. A new dialog box will open where you can **name** your branch and optionally provide a **description** for it.
+1. Hover over the model button. “**+**” button will appear on the left. Click on it.
+2. A new dialog box will open where you can **name** your model and optionally provide a **description** for it.
 3. Click on "**Create**".
 
-The newly created branch will become active, ready for you to start working on it.
+The newly created model will become active, ready for you to start working on it.
 
-## Adding a Stream by URL
+## Adding a Project by URL
 
 <video autoplay muted loop>
   <source src="./img-sketchup/add-by-id.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 
-If you have the URL of the data you want to receive, you can easily add it using the "**Add By ID or URL**" button. Paste the URL of the data you want to receive and click “**Add**”. A Stream Card will be added, with the branch and commit selected from the pasted URL.
+If you have the URL of the project you want to receive, you can easily add it using the "**Add By ID or URL**" button. Paste the URL of the data you want to receive and click “**Add**”. A Project Card will be added, with the model and version selected from the pasted URL.
 
 ## Switching Accounts
 

--- a/user/teklastructures.md
+++ b/user/teklastructures.md
@@ -22,7 +22,7 @@ Once installed, you can find the Tekla Structures connector in the Application a
 
 ### Recieving in Tekla Structures
 
-Save the Tekla Structures model as a file first before attempting to recieve streams into your Tekla Structures model.
+Save the Tekla Structures model as a file first before attempting to recieve projects into your Tekla Structures model.
 
 ## User Interface
 
@@ -30,13 +30,13 @@ Save the Tekla Structures model as a file first before attempting to recieve str
 
 This connector uses our shared Desktop UI2. Read up on general guidelines for usage in the [Desktop UI2 section](https://speckle.community/t/new-desktopui-in-alpha-testing/1851/2).
 
-**Streams are saved to a textfile that will appear in your model folder titled "Speckle". Do not delete this folder.**
+**Projects are saved to a textfile that will appear in your model folder titled "Speckle". Do not delete this folder.**
 
 :::
 
 ### Filters
 
-To help you select which elements will be to sent to Speckle, we've built various filters into our Tekla Structures connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your Stream. Section properties and materials defined within the model will always be sent.
+To help you select which elements will be to sent to Speckle, we've built various filters into our Tekla Structures connector. Once a filter is set, just click **Send** and all objects passing the filter will be sent to your Project. Section properties and materials defined within the model will always be sent.
 
 _Please Note: Elements are sent regardless of whether they are visible or if they were created after setting up the filter._
 
@@ -64,7 +64,7 @@ This trivial filter allows you to select all the elements that are currently sup
 
 ## Updating Elements
 
-The connector does not take care of updating existing elements within the stream.
+The connector does not take care of updating existing elements within the project.
 
 ## Revit & BIM Data to Tekla Structures
 

--- a/user/ui.md
+++ b/user/ui.md
@@ -22,44 +22,44 @@ Let's go on a quick graphical tour of the shared user interface to get you famil
 
 ## Connector Home Page
 
-When launching a Connector in your host application (e.g. Rhino), you'll be presented with our **home page**, which contains a list of all the streams loaded into whichever file you're in. Each stream displays its name, alongside a host of buttons.
+When launching a Connector in your host application (e.g. Rhino), you'll be presented with our **home page**, which contains a list of all the projects loaded into whichever file you're in. Each project displays its name, alongside a host of buttons.
 
 ### Sender or Receiver?
 
-When viewed in the Connector, a stream can be in either _Sender_ or _Receiver_ mode, which determines whether you're sending data to your Speckle server or receiving data from it. The easiest way to tell which mode it's in is to check whether the stream has a **Send** or a **Receive** button (you can toggle between these two states using the switch button.)
+When viewed in the Connector, a project can be in either _Sender_ or _Receiver_ mode, which determines whether you're sending data to your Speckle server or receiving data from it. The easiest way to tell which mode it's in is to check whether the project has a **Send** or a **Receive** button (you can toggle between these two states using the switch button.)
 
 ![desktopui home page with labelled buttons](https://user-images.githubusercontent.com/7717434/107382404-badd7f80-6ae7-11eb-9941-2265b1cc5748.png)
 
-Your streams have several buttons along the bottom, which can vary depending on whether they are in _Sender_ or _Receiver_ mode. The leftmost button lets you create and switch between the stream's branches (if you have any).
+Your projects have several buttons along the bottom, which can vary depending on whether they are in _Sender_ or _Receiver_ mode. The leftmost button lets you create and switch between the project's models (if you have any).
 
-The center button changes, depending on the stream's mode:
+The center button changes, depending on the project's mode:
 
-- On a stream in _Receiver_ mode, the center button allows you to choose which commit you would like to receive.
-- On a stream in _Sender_ mode, the center button lets you select which objects in your model should be sent to this stream.
+- On a project in _Receiver_ mode, the center button allows you to choose which version you would like to receive.
+- On a project in _Sender_ mode, the center button lets you select which objects in your model should be sent to this project.
 
-The rightmost button is the Send/Receive button, for pushing/pulling data to (or from) this stream. This is where the Speckle magic happens!
+The rightmost button is the Send/Receive button, for pushing/pulling data to (or from) this project. This is where the Speckle magic happens!
 
-### Selecting a Stream
+### Selecting a Project
 
-The first step of using Speckle is getting your hands on a stream. The Connector lets you create streams from scratch and/or retrieve streams that already exist.
+The first step of using Speckle is getting your hands on a project. The Connector lets you create projects from scratch and/or retrieve projects that already exist.
 
-Click the big blue '+' button to get started; it opens a pop up window where you can select a recently-used stream or search for an existing stream. Alternatively, you can start typing to create and name a new stream.
+Click the big blue '+' button to get started; it opens a pop up window where you can select a recently-used project or search for an existing project. Alternatively, you can start typing to create and name a new project.
 
-## Stream Details Page
+## Project Details Page
 
-Either way, once you've got a stream, you can click on its name to go to the stream details page. Here you can edit the stream's name or description, manage collaborators, or remove it from the connector.
+Either way, once you've got a project, you can click on its name to go to the project details page. Here you can edit the project's name or description, manage collaborators, or remove it from the connector.
 
-![desktopui-new-stream](https://user-images.githubusercontent.com/7717434/106741747-08ec1200-6614-11eb-9162-829670899da9.gif)
+![desktopui-new-project](https://user-images.githubusercontent.com/7717434/106741747-08ec1200-6614-11eb-9162-829670899da9.gif)
 
 ::: tip
 
-Please note, removing a stream from the Connector will just disassociate it from the file you're in. In order to delete a stream, you'll need to access it via the [Speckle Web App](./web) (i.e. in your browser).
+Please note, removing a project from the Connector will just disassociate it from the file you're in. In order to delete a project, you'll need to access it via the [Speckle Web App](./web) (i.e. in your browser).
 
 :::
 
 ## Sending Data
 
-In order to send data to your stream, you'll need to tell Speckle which elements should be sent. Is it:
+In order to send data to your project, you'll need to tell Speckle which elements should be sent. Is it:
 
 - Just the items you've selected?
 - A specific layer(s) in Rhino?
@@ -71,7 +71,7 @@ _Please Note: The examples we're showing below are a bit Revit-specific._
 
 ### Adding Objects
 
-The simplest way to add objects to a stream is by selecting what you want in the file, clicking the centre selection button, and choosing the "Set Selection" option. However, you can also get more granular control of your object selection by diving into the filter options.
+The simplest way to add objects to a project is by selecting what you want in the file, clicking the centre selection button, and choosing the "Set Selection" option. However, you can also get more granular control of your object selection by diving into the filter options.
 
 ![image-20210303192353932](https://user-images.githubusercontent.com/2679513/127769268-6c954611-ab5b-4e8b-ac80-8bc4c00a6d40.png)
 
@@ -83,21 +83,21 @@ By clicking on any of the (2) buttons instead, the elements are added/removed ba
 
 ### Sending Data
 
-When you're ready to send your data to your stream, hit that big blue "Send" button!
+When you're ready to send your data to your project, hit that big blue "Send" button!
 
-_Pro tip: If you want to add a commit message, click the three dots menu next to the send button first._
+_Pro tip: If you want to add a version message, click the three dots menu next to the send button first._
 
 ![desktopui-commit-message](https://user-images.githubusercontent.com/7717434/106741155-3c7a6c80-6613-11eb-8273-ef59e7261ceb.gif)
 
 Here's a recap in the form of a snappy gif:
 
-![desktopui-send-stream](https://user-images.githubusercontent.com/7717434/106739196-c248e880-6610-11eb-8cc5-01216cc980b1.gif)
+![desktopui-send-project](https://user-images.githubusercontent.com/7717434/106739196-c248e880-6610-11eb-8cc5-01216cc980b1.gif)
 
 ## Receiving Data
 
-For streams in Receiver mode, the central button lets you control which commit's data you want to receive. You can either choose to stay up to date with the latest commit or stick to a specific commit. Just press the Commit button and select your desired option.
+For projects in Receiver mode, the central button lets you control which version's data you want to receive. You can either choose to stay up to date with the latest version or stick to a specific version. Just press the Version button and select your desired option.
 
-If you choose to stay on the "latest" commit, you won't be updated automatically. You'll see a notification that things have changed and you will be prompted to click the "Receive" button to sync up.
+If you choose to stay on the "latest" version, you won't be updated automatically. You'll see a notification that things have changed and you will be prompted to click the "Receive" button to sync up.
 
 ![desktopui-switch-cards](https://user-images.githubusercontent.com/7717434/106739209-c5dc6f80-6610-11eb-8625-01b19240c612.gif)
 

--- a/user/ui2.md
+++ b/user/ui2.md
@@ -18,44 +18,44 @@ Let's go on a quick graphical tour of the shared user interface to get you famil
 
 ## Main View
 
-When launching a Connector for the first time inside a document, you'll first see a list with the latest streams available in **all your account**:
+When launching a Connector for the first time inside a document, you'll first see a list with the latest projects available in **all your account**:
 
 ![dui2](https://user-images.githubusercontent.com/2679513/159477337-7df363f5-4d72-419f-9a67-c880b84242e6.gif)
 
-In this same view you'll also be able to search streams, create a new stream or to add one from a URL.
+In this same view you'll also be able to search projects, create a new project or to add one from a URL.
 
-### Selecting a Stream
+### Selecting a Project
 
-You can select a stream in various ways. If you have access to it and it's been used recently you should see it in the main list.
-We have also added a button to quickly view the stream online.
+You can select a project in various ways. If you have access to it and it's been used recently you should see it in the main list.
+We have also added a button to quickly view the project online.
 
 Alternatively you can search for it (by name or ID), or add it by URL.
 
-Adding a stream by URL is very useful when you want to receive from a public stream of which you are not a collaborator.
+Adding a project by URL is very useful when you want to receive from project of which you are not a team member but is Link Shared.
 
-## Stream View
+## Project View
 
-After selecting a stream, you'll see the Stream View.
+After selecting a project, you'll see the Project View.
 
-At the top you'll be able to see all the recent send & receive activity for the stream.
+At the top you'll be able to see all the recent send & receive activity for the project.
 
 At the bottom, you can select whether you want to send or receive from it.
 
-![dui2-stream](https://user-images.githubusercontent.com/2679513/159477977-6468748a-e73b-4be6-924b-00cb08121efb.gif)
+![dui2-project](https://user-images.githubusercontent.com/2679513/159477977-6468748a-e73b-4be6-924b-00cb08121efb.gif)
 
 ### Sending
 
-When sending to a stream, you'll be able to decide which branch to use and what elements to send.
+When sending to a project, you'll be able to decide which model to use and what elements to send.
 Each connector has built in filters to help you select elements in ways that make the most sense for the application you're using.
 
 ![Revit_rlKM6e6qTn](https://user-images.githubusercontent.com/51519350/186396184-be4fd296-8be2-4657-89b8-943170be4304.png)
 
-#### Branch Selection
+#### Model Selection
 
-Data in a stream can be organized in branches, for instance, to have multiple design options or to store data by discipline.
-The default branch is called main, you can select the branch you want to send to by using the dropdown.
+Data in a project can be organized in models, for instance, to have multiple design options or to store data by discipline.
+The default model is called main, you can select the model you want to send to by using the dropdown.
 
-If you want to create a new branch, you can do so from the [web](./web) interface.
+If you want to create a new model, you can do so from the [web](./web) interface.
 
 ![Revit_nNrp8zDlw1](https://user-images.githubusercontent.com/51519350/186396455-838408eb-039b-4615-a2ab-2401b18b5099.png)
 
@@ -73,10 +73,10 @@ For instance in Revit you can send:
 
 ![dui2-send-filter](https://user-images.githubusercontent.com/2679513/139485797-bd26ef1c-9366-43a2-b14b-9c6f14dbb9bd.gif)
 
-#### Commit Message
+#### Version Message
 
 When sending to Speckle, it's always good to include a message describing what you're sending or explaining the changes applied since the last send operation.
-The commit message is saved and re-used in future sends.
+The version message is saved and re-used in future sends.
 
 ![Revit_NKzJqG4NoT](https://user-images.githubusercontent.com/51519350/186397873-1c889e61-2a06-467c-a073-d38ae6c0b345.gif)
 
@@ -86,29 +86,29 @@ You can now click "Save 💾" and these options will be saved locally in the cur
 
 ![image](https://user-images.githubusercontent.com/51519350/186397368-5e6ed7ec-c32c-40dd-a8f4-685325406d33.png)
 
-If instead you want to send already, just click on "Send", the stream will also be saved.
+If instead you want to send already, just click on "Send", the project will also be saved.
 
 ### Receiving
 
 Similarly to sending data, the Receiving comes with a few options.
 
-#### Branch Selection
+#### Model Selection
 
-Data in a stream can be organized in branches, for instance, to have multiple design options or to store data by discipline.
-The default branch is called main, you can select the branch you want to receive from by using the dropdown.
+Data in a project can be organized in models, for instance, to have multiple design options or to store data by discipline.
+The default model is called main, you can select the model you want to receive from by using the dropdown.
 
 ![image](https://user-images.githubusercontent.com/51519350/186398225-d9759a2d-6695-4aa6-a857-ae152b77eb5b.png)
 
-If a branch has no data in it, you will not be able to use it.
+If a model has no data in it, you will not be able to use it.
 
-#### Commit Selection
+#### Version Selection
 
-A commit is a snapshot in time of the data inside a branch. Every time you send to Speckle from a connector, a commit is created.
-With the commit selection dropdown you can specify whether to receive a specific commit, or to always get the latest available for the selected branch.
+A version is a snapshot in time of the data inside a model. Every time you send to Speckle from a connector, a version is created.
+With the version selection dropdown you can specify whether to receive a specific version, or to always get the latest available for the selected model.
 
-If you choose to stay on the "latest" commit, you'll get a notification every time new data is sent to that branch.
+If you choose to stay on the "latest" version, you'll get a notification every time new data is sent to that model.
 
-If a preview is available it will be displayed when selecting a commit.
+If a preview is available it will be displayed when selecting a version.
 
 ![Revit_WrPYfd3bxG](https://user-images.githubusercontent.com/51519350/186398705-112a5491-78a9-4cbd-b311-d3b60ff109b0.gif)
 
@@ -120,9 +120,9 @@ You can now click "Save" and these options will be saved locally in the current 
 
 If instead you are ready to receive, just click on "Receive".
 
-## Saved Streams
+## Saved Projects
 
-Saved streams will show up under a "Saved Streams" list.
+Saved projects will show up under a "Saved Projects" list.
 
 ![dui2-saved](https://user-images.githubusercontent.com/2679513/159479002-ea661bad-4f43-46f9-a810-8a4780c8a056.gif)
 
@@ -140,6 +140,10 @@ This menu is customizable, and every Connector will have slightly different acti
 
 ## Accounts
 
-From Speckle 2.5.0 onwards it is possible to log into Speckle and manage your accounts directly from this user interface.
+It is possible to log into Speckle and manage your accounts directly from this user interface.
 
 ![dui2-account](https://user-images.githubusercontent.com/2679513/159479841-3cb0f858-4107-4550-bde8-abbeb1415924.gif)
+
+## Legacy Terminology
+
+In the past, we used to call "streams" what we now call "projects". We've updated the terminology to make it more intuitive for new users. If you are using a legacy server, we have retained an option to switch the terminology used in the user interface to "streams", "branches" and "commits".

--- a/user/unity.md
+++ b/user/unity.md
@@ -72,7 +72,7 @@ To receive data please refer to the [`Receiver.cs`](https://github.com/specklesy
 
 ```csharp
 var receiver = myGameObject.AddComponent<Receiver>();
-receiver.Init(streamId);
+receiver.Init(projectId);
 receiver.Receive();
 ```
 
@@ -84,7 +84,7 @@ To send data please refer to the [`Sender.cs`](https://github.com/specklesystems
 
 ```csharp
 var sender = myGameObject.AddComponent<Sender>();
-sender.Send(streamId, objs);
+sender.Send(projectId, objs);
 ```
 
 The `Send()` method accepts additional optional arguments to use different accounts, report progress and errors etc. Please check the [source code](https://github.com/specklesystems/speckle-unity/blob/main/Assets/Speckle%20Connector/Sender.cs) for a complete list.

--- a/user/unreal.md
+++ b/user/unreal.md
@@ -67,23 +67,23 @@ Here is how to use it:
 
 3. There are **two ways to import objects** using the `Speckle Unreal Manager` actor.
 
-::: tip Import <b>a specific object</b> id, by specifying a <i>Server URL</i> + <i>Stream id</i> + <i>Object id</i>
+::: tip Import <b>a specific object</b> id, by specifying a <i>Server URL</i> + <i>Project id</i> + <i>Object id</i>
 
 <p><details>
 <summary>Expand</summary>
 
->**1.** Firstly, ensure the **"specify by object id" checkbox is checked**, and the **Sever URL** matches the Speckle server you are using (default [`https://speckle.xyz`](https://speckle.xyz))
+>**1.** Firstly, ensure the **"specify by object id" checkbox is checked**, and the **Sever URL** matches the Speckle server you are using (default [`https://app.speckle.systems`](https://app.speckle.systems))
 
->**2.** Enter the **Stream ID**. This can be copied from the url of your stream, and pasted into the "Stream ID" property of your `Speckle Unreal Manager`.
-><center><img src="./img-unreal/finding_stream_id.png" width="75%" alt="screenshot of a speckle stream url https://speckle.xyz/streams/76c45cdb32, with the stream id 76c45cdb32 highlighted"/></center>
+>**2.** Enter the **Project ID**. This can be copied from the url of your project, and pasted into the "Project ID" property of your `Speckle Unreal Manager`.
+><center><img src="./img-unreal/finding_stream_id.png" width="75%" alt="screenshot of a speckle project url https://app.speckle.systems/streams/76c45cdb32, with the project id 76c45cdb32 highlighted"/></center>
 
 
 >**3.** Enter the  **Object ID** of the object you want to receive.
->You can explore the objects in a stream by using the [Speckle Web App](/user/web) for the Speckle server that you use.
-><center><img src="./img-unreal/finding_object_id.png" width="75%" alt="screenshot of the property panel of a Speckle commit,> highlighting the object ID of the selected (root) object"/></center>
+>You can explore the objects in a project by using the [Speckle Web App](/user/web) for the Speckle server that you use.
+><center><img src="./img-unreal/finding_object_id.png" width="75%" alt="screenshot of the property panel of a Speckle version,> highlighting the object ID of the selected (root) object"/></center>
 
 >**4. If the stream is private**, you will need to generate an **auth token**.
->To do so, head to your profile page [https://speckle.xyz/profile](https://speckle.xyz/profile), and generate a new Access Token (with all scopes)
+>To do so, head to your profile page [https://app.speckle.systems/profile](https://app.speckle.systems/profile), and generate a new Access Token (with all scopes)
 ><center><img src="./img-unreal/generate_auth_token.png" width="75%" alt="screen shot of profile page, with arrow pointing towards the new token button"/></center>
 
 </details></p>
@@ -93,22 +93,22 @@ Here is how to use it:
 
 <center><b>OR</b></center>
 
-::: tip Import <b>a speckle commit</b>, by specifying a <i>Server URL</i> + <i>Auth Token</i>, and then select a <i>Stream</i> + <i>Branch</i> + <i>Commit</i> from the drop down menu.
+::: tip Import <b>a speckle version</b>, by specifying a <i>Server URL</i> + <i>Auth Token</i>, and then select a <i>project</i> + <i>model</i> + <i>version</i> from the drop down menu.
 <p><details>
 <summary>Expand</summary>
 
 >**1.** First, you must authenticate your Speckle account.<br/>
 > Currently, this can only be done via an **auth token** (aka personal access token).<br/>
-> To generate one, head to your profile page <a href="https://speckle.xyz/profile">https://speckle.xyz/profile</a>, and under "Access Token", generate a new token **with all scopes**.
+> To generate one, head to your profile page <a href="https://app.speckle.systems/profile">https://app.speckle.systems/profile</a>, and under "Access Token", generate a new token **with all scopes**.
 ><center><img src="./img-unreal/generate_auth_token.png" width="75%" alt="screen shot of profile page, with arrow pointing towards the new token button"/></center>
 
 >**2.** Paste the auth token into your `Speckle Unreal Manager` actor (also, ensure the `ServerUrl` is correct)
 
->**3.** Deselect the "specify by object id" option, and, assuming the url + token is valid, the drop down selections for `Stream`, `Branch`, and `Commit` will be available.
+>**3.** Deselect the "specify by object id" option, and, assuming the url + token is valid, the drop down selections for `project`, `model`, and `version` will be available.
 >
 ><center><video width="66%" loop controls autoplay muted><source src="./img-unreal/stream.branch.commit.selection.mp4" type="video/mp4">Your browser does not support the video tag.</video></center>
 
-> (optional notes) The number of stream/branch/commits is capped, by default at 15, but this value can be adjusted under the advanced settings `options limit` value.
+> (optional notes) The number of project/model/versions is capped, by default at 15, but this value can be adjusted under the advanced settings `options limit` value.
 > If no options appear, then try deselecting, and reselecting the actor, and check the `Output Log` for warnings.
 
 </details></p>
@@ -142,7 +142,7 @@ It fetches JSON objects from the server, which are then stored in a local `Memor
 An example of this process in Blueprint is provided in the `Plugins\speckle-unreal\Content\Examples` directory and looks like this:
 <center><img src="./img-unreal/receiving_bp.png" width="100%" /></center>
 
-Additionally, a number of Blueprint macro nodes are provided to fetch details about streams/branch/commits/users.
+Additionally, a number of Blueprint macro nodes are provided to fetch details about project/model/version/users.
 Checkout our [dedicated tutorial on the topic](https://speckle.systems/tutorials/unreal-engine-blueprint-nodes-fetch-stream-branch-commit-info-and-more/), covering how to use the provided GraphQL nodes, and also how to easily develop your own query macros.
 
 

--- a/user/web.md
+++ b/user/web.md
@@ -10,11 +10,11 @@ The **Speckle Web App** is our browser-based interface for managing all things S
 - Viewing your data in our 3D model viewer
 - Managing your account
 
-When you first visit your speckle server address (e.g. our default [speckle.xyz server](https://speckle.xyz)), you'll be prompted to log in or register to that server. Servers are independent of each other meaning if you are a part of multiple Speckle Servers, you'll need to create a new account for each one.
+When you first visit your speckle server address (e.g. our default [general availibility server](https://app.speckle.systems)), you'll be prompted to log in or register to that server. Servers are independent of each other meaning if you are a part of multiple Speckle Servers, you'll need to create a new account for each one.
 
 ::: tip 🙌 IMPORTANT
 This guide assumes you have a **Speckle Account**.
-If you don't, register on our [free XYZ Speckle server](https://speckle.xyz).
+If you don't, register on our [General Availabilty Speckle server](https://app.speckle.systems).
 :::
 
 ## Streams
@@ -90,7 +90,7 @@ Use your left mouse button to rotate the view around and use the right mouse but
 
 Try playing with our embedded 3D viewer below to get a feel for navigating a model and inspecting its elements in your browser.
 
-<iframe src="https://speckle.xyz/embed?stream=a632e7a784&branch=roof" width=600 height=400></iframe>
+<iframe src="https://app.speckle.systems/projects/a632e7a784/models/1b47b19207#embed=%7B%22isEnabled%22%3Atrue%7D" width=600 height=400></iframe>
 
 The toolbar at the bottom edge of the viewer allows you to:
 
@@ -104,7 +104,7 @@ The toolbar at the bottom edge of the viewer allows you to:
 You can easily embed any stream, branch, commit or object directly from the **web app**. To do so, just follow these steps:
 
 ::: warning 📌 Please Note
-Your stream must be made **public** in order for the embedded viewer to properly load.
+Your stream must be made **Link Shared** in order for the embedded viewer to properly load.
 :::
 
 1. In the **_web app_**, go to a stream page containing _geometric data_.


### PR DESCRIPTION
This is an integration commit for the virtual branches that GitButler is tracking.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - jsdb/fe2-terminology (refs/gitbutler/jsdb/fe2-terminology) branch head: adbfd6724ab73e772d25dddb7c5d75d0d785217f
   - user/ifc.md
   - user/autocadcivil.md
   - user/archicad.md
   - user/arcgis.md
   - user/sketchup.md
   - user/web.md
   - user/csi.md
   - user/unreal.md
   - user/mapping-tool.md
   - user/bentley.md
   - user/connectors.md
   - .vuepress/config.js
   - user/FAQs.md
   - user/ui.md
   - user/blender.md
   - user/concepts.md
   - user/ui2.md
   - user/rhino.md
   - user/quickstart.md
   - user/excel.md
   - user/installing.md
   - user/unity.md
   - user/revit.md
   - user/README.md
   - user/teklastructures.md
   - user/concepts-advanced.md
   - user/qgis.md
   - user/powerbi/accessing-private-streams.md
   - user/sketchup/basic-usage.md
   - user/powerbi-visual/basic-usage.md
   - user/sketchup/advanced-settings.md
   - user/powerbi/using-powerbi-connector.md
   - user/powerbi/introduction.md
   - user/revit/sending-models.md
   - user/revit/features.md

Your previous branch was: refs/heads/jsdb/fe2-terminology

The sha for that commit was: 2d27c67d7efee575d25d78cd4c48ae6be0dceef8

For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch