### PR TITLE
Fix traefik configuration in manual setup

### DIFF
--- a/dev/server-manualsetup.md
+++ b/dev/server-manualsetup.md
@@ -252,6 +252,7 @@ The server also supports some other environment variables. You can see them in o
   services:
     reverse-proxy:
       image: traefik:v2.10
+      restart: always
       command:
         - "--providers.docker=true"
         - "--providers.docker.exposedbydefault=false"


### PR DESCRIPTION
The manual setup guide claims that "All containers automatically start at system startup (so if the VM gets rebooted, the Server will automatically start)" but this requires all containers to be defined with `restart: always`.