### PR TITLE
Viewer Updates

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -294,6 +294,7 @@ module.exports = {
           title: "API Reference",
           collapsable: false,
           children: [
+            "migration-guide",
             {
               title: "Viewer Core",
               collapsable: true,

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -306,6 +306,7 @@ module.exports = {
                 "input-api",
                 "intersections-api",
                 "loader-api",
+                "queries-api",
                 "render-view-api",
                 "render-tree-api",
                 "speckle-material-api",
@@ -319,6 +320,7 @@ module.exports = {
               title: "Extensions",
               collapsable: true,
               children: [
+                "extension-api",
                 "camera-controller-api",
                 "diff-extension-api",
                 "filtering-extension-api",

--- a/viewer/acceleration-structure-api.md
+++ b/viewer/acceleration-structure-api.md
@@ -22,8 +22,8 @@ The speckle viewer uses a dual level BVH for optimal acceleration. The Accelerat
 
 ### <h3>Typedefs</h3>
 
-| [VectorLike](/viewer/acceleration-structure-api.md#vectorlike) |
-| -------------------------------------------------------------- |
+| [VectorLike](/viewer/acceleration-structure-api.md#vectorlike) | [BVHOptions](/viewer/acceleration-structure-api.md#bvhoptions)
+| -------------------------------------------------------------- | -------------------------------------------------------------- |
 
 ### <h3>Constructors</h3>
 
@@ -83,7 +83,7 @@ Build a BVH using the provided geometry data.
 
 - **indices**: Geometry indices
 - **position**: Geometry vertex positions
-- **options**: [_BVHOptions_]()
+- **options**: [_BVHOptions_](/viewer/acceleration-structure-api.md#bvhoptions)
 - _optional_ **transform**: A [_Matrix4_](https://threejs.org/docs/index.html?q=matri#api/en/math/Matrix4) that transforms the geometry data before building the BVH
 
 **Returns**: [_MeshBVH_](https://github.com/gkjohnson/three-mesh-bvh/blob/master/src/core/MeshBVH.js)
@@ -242,3 +242,20 @@ type VectorLike = { x: number; y: number; z?: number; w?: number };
 ```
 
 Archtype for Vector2, Vector3 and Vector4.
+
+#### <b>BVHOptions</b>
+
+```ts
+interface BVHOptions {
+  strategy: SplitStrategy
+  maxDepth: number
+  maxLeafTris: number
+  verbose: boolean
+  useSharedArrayBuffer: boolean
+  setBoundingBox: boolean
+  onProgress?: () => void
+  [SKIP_GENERATION]: boolean
+}
+```
+
+Based off the original options defined in [_three-mesh-bvh_](https://github.com/gkjohnson/three-mesh-bvh/blob/a3a7ca7b2b275606963a616c80ca1262a7e48d7f/src/core/MeshBVH.js#L29)

--- a/viewer/batch-api.md
+++ b/viewer/batch-api.md
@@ -123,7 +123,7 @@ get groups(): DrawGroup[]
 
 Gets the current list of draw groups. A draw group is equivalent to a draw call.
 
-**Returns**: [_DrawGroup[]_]()
+**Returns**: [_DrawGroup[]_](/viewer/batch-api.md#drawgroup)
 
 #### <b>materials</b>
 
@@ -348,7 +348,7 @@ Resets the batch to its default state where there is a single draw group rendere
 setBatchBuffers(range: BatchUpdateRange[]): void
 ```
 
-Updates relevant batch buffers based on the [_MaterialOptions_]() from the provided [_BatchUpdateRange_](/viewer/batch-api.md#batchupdaterange). Implementation specific.
+Updates relevant batch buffers based on the [_MaterialOptions_](/viewer/speckle-material-api.md#materialoptions) from the provided [_BatchUpdateRange_](/viewer/batch-api.md#batchupdaterange). Implementation specific.
 
 **Parameters**
 

--- a/viewer/batch-object-api.md
+++ b/viewer/batch-object-api.md
@@ -58,7 +58,7 @@ get accelerationStructure(): AccelerationStructure
 
 Gets the object's bottom level BVH.
 
-**Returns**: [_AccelerationStructure_]()
+**Returns**: [_AccelerationStructure_](/viewer/acceleration-structure-api.md)
 
 #### <b>batchIndex</b>
 
@@ -98,7 +98,7 @@ Gets the start index inside the batch's index buffer.
 buildAccelerationStructure(bvh?: MeshBVH)
 ```
 
-Build this object's [_AccelerationStructure_]() either from scratch, using the render view's geometry, either by using the optional bvh argument. BVH's can be shared between objects as long as it makes sense like for example for instances.
+Build this object's [_AccelerationStructure_](/viewer/acceleration-structure-api.md) either from scratch, using the render view's geometry, either by using the optional bvh argument. BVH's can be shared between objects as long as it makes sense like for example for instances.
 :::tip
 The speckle viewer uses the [three-mesh-bvh](https://github.com/gkjohnson/three-mesh-bvh) library as the backbone for any BVH related operations.
 :::

--- a/viewer/camera-controller-api.md
+++ b/viewer/camera-controller-api.md
@@ -17,7 +17,7 @@ The default camera controller extension that comes with the viewer package. Incl
 
 ### <h3>Typedefs</h3>
 
-| [CameraControllerEvent](/viewer/camera-controller-api.md#cameracontrollerevent) | [CameraProjection](/viewer/camera-controller-api.md#cameraprojection) | [CanonicalView](/viewer/camera-controller-api.md#canonicalview) | [InlineView](/viewer/camera-controller-api.md#inlineview) |
+| [CameraEvent](/viewer/camera-controller-api.md#cameraevent) | [CameraProjection](/viewer/camera-controller-api.md#cameraprojection) | [CanonicalView](/viewer/camera-controller-api.md#canonicalview) | [InlineView](/viewer/camera-controller-api.md#inlineview) |
 | :------------------------------------------------------------------------------ | :-------------------------------------------------------------------- | :-------------------------------------------------------------- | :-------------------------------------------------------- |
 | [PolarView](/viewer/camera-controller-api.md#polarview)                         |                                                                       |                                                                 |
 
@@ -105,14 +105,14 @@ Enables all camera controls rotation capabilities.
 #### <b>on</b>
 
 ```ts
-on(e: CameraControllerEvent, handler: (data: boolean) => void)
+on(e: CameraEvent, handler: (data: boolean) => void)
 ```
 
 Function for subscribing to camera events.
 
 **Parameters**
 
-- **e**: [_CameraControllerEvent_]()
+- **e**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
 - **handler**: The handler for the events
 
 **Returns**: void
@@ -120,14 +120,14 @@ Function for subscribing to camera events.
 #### <b>removeListener</b>
 
 ```ts
-removeListener(e: CameraControllerEvent, handler: (data: unknown) => void)
+removeListener(e: CameraEvent, handler: (data: unknown) => void)
 ```
 
 Function for un-subscribing from camera events.
 
 **Parameters**
 
-- **e**: [_CameraControllerEvent_]()
+- **e**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
 - **handler**: The handler for the events to unsubscribe
 
 **Returns**: void
@@ -172,7 +172,7 @@ Focuses the camera based on explicit view models provided.
 
 **Parameters**
 
-- **view**: Explicit view of different possible type: [_CanonicalView_](), [_SpeckleView_](), [_InlineView_]()
+- **view**: Explicit view of different possible type: [_CanonicalView_](/viewer/camera-controller-api.md#canonicalview), [_SpeckleView_](/viewer/camera-controller-api.md#speckleview), [_InlineView_](/viewer/camera-controller-api.md#inlineview)
 - **transition**: Whether or not to make the transition animated
 - _optional_ **fit**: Linear tolerance
 
@@ -222,10 +222,10 @@ Switches between perspective and orthographic cameras.
 
 ### <h3>Typedefs</h3>
 
-#### <b>CameraControllerEvent</b>
+#### <b>CameraEvent</b>
 
 ```ts
-enum CameraControllerEvent {
+enum CameraEvent {
   Stationary,
   Dynamic,
   FrameUpdate,

--- a/viewer/camera-controller-api.md
+++ b/viewer/camera-controller-api.md
@@ -17,9 +17,9 @@ The default camera controller extension that comes with the viewer package. Incl
 
 ### <h3>Typedefs</h3>
 
-| [CameraEvent](/viewer/camera-controller-api.md#cameraevent) | [CameraProjection](/viewer/camera-controller-api.md#cameraprojection) | [CanonicalView](/viewer/camera-controller-api.md#canonicalview) | [InlineView](/viewer/camera-controller-api.md#inlineview) |
+| [CameraEvent](/viewer/camera-controller-api.md#cameraevent) | [CameraEventPayload](/viewer/camera-controller-api.md#cameraeventpayload) | [CameraProjection](/viewer/camera-controller-api.md#cameraprojection) | [CanonicalView](/viewer/camera-controller-api.md#canonicalview) |
 | :------------------------------------------------------------------------------ | :-------------------------------------------------------------------- | :-------------------------------------------------------------- | :-------------------------------------------------------- |
-| [PolarView](/viewer/camera-controller-api.md#polarview)                         |                                                                       |                                                                 |
+| [InlineView](/viewer/camera-controller-api.md#inlineview)                         |       [PolarView](/viewer/camera-controller-api.md#polarview)                                                                |                                                                 |
 
 ### <h3>Accessors</h3>
 
@@ -105,14 +105,17 @@ Enables all camera controls rotation capabilities.
 #### <b>on</b>
 
 ```ts
-on(e: CameraEvent, handler: (data: boolean) => void)
+on<T extends CameraEvent>(
+  eventType: T,
+  listener: (arg: CameraEventPayload[T]) => void
+): void
 ```
 
 Function for subscribing to camera events.
 
 **Parameters**
 
-- **e**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
+- **eventType**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
 - **handler**: The handler for the events
 
 **Returns**: void
@@ -226,16 +229,31 @@ Switches between perspective and orthographic cameras.
 
 ```ts
 enum CameraEvent {
-  Stationary,
-  Dynamic,
-  FrameUpdate,
-  ProjectionChanged,
+  Stationary = 'stationary',
+  Dynamic = 'dynamic',
+  FrameUpdate = 'frame-update',
+  ProjectionChanged = 'projection-changed'
 }
 ```
 
 Events the camera controller puts out.
 
 **Returns**: void
+
+#### <b>CameraEventPayload</b>
+
+```ts
+interface CameraEventPayload {
+  [CameraEvent.Stationary]: void
+  [CameraEvent.Dynamic]: void
+  [CameraEvent.FrameUpdate]: boolean
+  [CameraEvent.ProjectionChanged]: CameraProjection
+}
+```
+Mapping CameraEvent types to handler argument type
+
+**Returns**: void
+
 
 #### <b>CameraProjection</b>
 

--- a/viewer/extension-api.md
+++ b/viewer/extension-api.md
@@ -1,0 +1,87 @@
+# Extension
+Base class for all extensions. Extensions are created via [_createExtension_](/viewer/viewer-api.md#createextension) method from the viewer instance.
+
+### <h3>Fields</h3>
+
+| [viewer](/viewer/extension-api.md#viewer) |
+| ------------------------------------------------ |
+
+### <h3>Accessors</h3>
+
+| [enabled](/viewer/extension-api.md#enabled) | [inject](/viewer/extension-api.md#inject) |
+| ------------------------------------ | ------------------------------------ |
+
+### <h3>Methods</h3>
+
+| [onEarlyUpdate](/viewer/extension-api.md#onearlyupdate)  | [onLateUpdate](/viewer/extension-api.md#onlateupdate) | [onRender](/viewer/extension-api.md#onrender) | [onResize](/viewer/extension-api.md#onresize) |
+| :------------------------------------------------------------------- | :--------------------------------------------------------------- | :------------------------------------------------- | :------------------------------------------------- |
+
+### <h3>Fields</h3>
+
+#### <b>viewer</b>
+
+```ts
+protected viewer: IViewer
+```
+All extensions hold a reference to the viewer implementation instance that spawned them
+<br>
+<br>
+
+### <h3>Accessors</h3>
+
+#### <b>enabled</b>
+
+```ts
+get enabled(): boolean
+set enabled(value: boolean)
+```
+All extensions should implement enabling/disabling themselves
+<br>
+<br>
+
+
+#### <b>inject</b>
+
+```ts
+get inject(): Array<Constructor<Extension>>
+```
+Gets the list of extensions that need to get injected on creation time. This is how an extension declares that it needs other extensions injected. Injection is automatically done when calling [_createExtension_](/viewer/viewer-api.md#createextension)
+
+<br>
+<br>
+
+### <h3>Methods</h3>
+
+#### <b>onEarlyUpdate</b>
+
+```ts
+onEarlyUpdate(deltaTime?: number)
+```
+Update function called before the viewer's update
+<br>
+<br>
+
+#### <b>onLateUpdate</b>
+
+```ts
+onLateUpdate(deltaTime?: number)
+```
+Update function called after the viewer's update
+<br>
+<br>
+
+#### <b>onRender</b>
+
+```ts
+onRender()
+```
+Render function called after the viewer's render
+<br>
+<br>
+
+#### <b>onResize</b>
+
+```ts
+onResize()
+```
+Called whenever a resize happens

--- a/viewer/intersections-api.md
+++ b/viewer/intersections-api.md
@@ -7,6 +7,12 @@ Entry point for intersecting and obtaining intersection data from the scene. Acc
 | [intersect](/viewer/intersections-api.md#intersect) | [intersectRay](/viewer/intersections-api.md#intersectray) |
 | --------------------------------------------------- | --------------------------------------------------------- |
 
+### <h3>Typedefs</h3>
+
+| [ExtendedIntersection](/viewer/intersections-api.m#extendedintersection) | [ExtendedMeshIntersection](/viewer/intersections-api.m#extendedmeshintersection)  | [MeshIntersection](/viewer/intersections-api.m#meshintersection) 
+| :------------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------- | 
+
+
 ### <h3>Methods</h3>
 
 #### <b>intersect</b>
@@ -16,11 +22,21 @@ intersect(
     scene: Scene,
     camera: Camera,
     point: Vector2,
-    nearest = true,
-    bounds: Box3 = null,
-    castLayers: Array<ObjectLayers> = undefined,
-    firstOnly = false
-  ): Array<Intersection>
+    castLayers: ObjectLayers.STREAM_CONTENT_MESH,
+    nearest?: boolean,
+    bounds?: Box3,
+    firstOnly?: boolean
+  ): Array<ExtendedMeshIntersection> | null
+
+intersect(
+    scene: Scene,
+    camera: Camera,
+    point: Vector2,
+    castLayers?: Array<ObjectLayers>,
+    nearest?: boolean,
+    bounds?: Box3,
+    firstOnly?: boolean
+  ): Array<ExtendedIntersection> | null
 ```
 
 Scene intersect function.
@@ -33,9 +49,10 @@ All intersect calls from this class will use the available acceleration structur
 - **scene**: [_Scene_](https://threejs.org/docs/index.html?q=scene#api/en/scenes/Scene)
 - **camera**: [_Camera_](https://threejs.org/docs/index.html?q=camera#api/en/cameras/Camera)
 - **point**: The NDC point to cast the ray from
+- **castLayers**: The [_ObjectLayers_](/viewer/viewer-api.md#objectlayers) enabled on the raycaster 
 - **nearest**: If the results should be sorted by dinstance. i.e nearest first
 - **bounds**: An optional bounds where the intersecting takes place. Everything outside this bounds is disregarded from the result list
-- **castLayers**: The [_ObjectLayers_](/viewer/viewer-api.md#objectlayers) enabled on the raycaster for this cast. Any object outside of these layers is disregarded from intersection
+for this cast. Any object outside of these layers is disregarded from intersection
 - **firstOnly**: When this flag is enabled the acceleration structure will stop traversing after encountering the first intersection. Only applies to meshes
 
 **Returns**: Array< Intersection > Three.js defined intersection
@@ -47,11 +64,20 @@ intersectRay(
     scene: Scene,
     camera: Camera,
     ray: Ray,
-    nearest = true,
-    bounds: Box3 = null,
-    castLayers: Array<ObjectLayers> = undefined,
-    firstOnly = false
-  ): Array<Intersection>
+    castLayers: ObjectLayers.STREAM_CONTENT_MESH,
+    nearest?: boolean,
+    bounds?: Box3,
+    firstOnly?: boolean
+  ): Array<ExtendedMeshIntersection> | null
+intersectRay(
+    scene: Scene,
+    camera: Camera,
+    ray: Ray,
+    castLayers?: Array<ObjectLayers>,
+    nearest?: boolean,
+    bounds?: Box3,
+    firstOnly?: boolean
+  ): Array<ExtendedIntersection> | null
 ```
 
 Scene intersect function using a provided Ray.
@@ -64,9 +90,42 @@ All intersect calls from this class will use the available acceleration structur
 - **scene**: [_Scene_](https://threejs.org/docs/index.html?q=scene#api/en/scenes/Scene)
 - **camera**: [_Camera_](https://threejs.org/docs/index.html?q=camera#api/en/cameras/Camera)
 - **ray**: The ray to use for casting
+- **castLayers**: The [_ObjectLayers_](/viewer/viewer-api.md#objectlayers) enabled on the raycaster 
 - **nearest**: If the results should be sorted by dinstance. i.e nearest first
 - **bounds**: An optional bounds where the intersecting takes place. Everything outside this bounds is disregarded from the result list
-- **castLayers**: The [_ObjectLayers_](/viewer/viewer-api.md#objectlayers) enabled on the raycaster for this cast. Any object outside of these layers is disregarded from intersection
+for this cast. Any object outside of these layers is disregarded from intersection
 - **firstOnly**: When this flag is enabled the acceleration structure will stop traversing after encountering the first intersection. Only applies to meshes
 
 **Returns**: Array< Intersection > Three.js defined intersection
+
+### <h3>Typedefs</h3>
+
+#### <b>ExtendedIntersection</b>
+
+```ts
+interface ExtendedIntersection extends Intersection {
+  batchObject?: BatchObject;
+  pointOnLine?: Material;
+}
+```
+
+Extension of three.js's default Intersection.
+
+#### <b>ExtendedMeshIntersection</b>
+
+```ts
+interface ExtendedMeshIntersection extends MeshIntersection {
+  batchObject: BatchObject
+  object: SpeckleMesh | SpeckleInstancedMesh
+}
+```
+
+#### <b>MeshIntersection</b>
+
+```ts
+interface MeshIntersection extends Intersection {
+  face: Face
+  faceIndex: number
+}
+```
+

--- a/viewer/measurements-tool-api.md
+++ b/viewer/measurements-tool-api.md
@@ -2,7 +2,7 @@
 
 This extension provides basic configurable measurement capabilities. The tool is autonomous, and is able to create measurements on it's own.
 :::warning
-This extension requires and active ICameraProvider extension implementation.
+This extension requires and active CameraController extension implementation.
 :::
 
 ### <h3>Accessors</h3>

--- a/viewer/migration-guide.md
+++ b/viewer/migration-guide.md
@@ -1,0 +1,109 @@
+# Migration Guide
+
+# 2.15.14 → 2.18.15
+- Asset now has a mandatory ```id``` field
+- `getEnvironment` and `getTexture` from `Assets` now only accept `Asset` as argument
+- The concept of `Providers` has been removed entirely
+- `CameraProvider` has been replaced by `SpeckleCamera`
+- `CameraControllerEvent` renamed to `CameraEvent`
+
+# 2.18 → 2.18.14
+
+- `updateClippingPlanes`  in `SpeckleRenderer`  does not take an optional `Plane[]` argument anymore
+- `setOptions` from `SelectionExtension` has changed to an accessor
+- `displayOn` and `displayOff` from `SectionTool` are replaced by `visible` accessor
+
+# 2.x → 2.18
+
+The introduction of viewer API 2.0 into our stable channel. The changes to the API itself are extensive and there is no point for a step by step guide, as what was previously known as API 2.0 will become the single supported viewer API moving forward.
+
+<h2>API 1.0 Backwards Compatibility:</h2>
+
+For **backwards compatibility** reasons we provide a built-in legacy implementation that emulates the old API precisely. Please note that this is meant as a temporary measure which will eventually become naturally obsolete. For this purpose, this migration guide entry will describe moving from any older viewer version to 2.18 *while using the legacy implementation*
+
+- `Viewer` or `DebugViewer` instances are replaced by `LegacyViewer`
+- The `hits`  field from `SelectionEvent` now holds the hit node and hit point.
+    
+    ```jsx
+    type SelectionEvent = {
+      multiple: boolean
+      event?: PointerEvent
+      hits: Array<{
+        node: TreeNode
+        point: Vector3
+      }>
+    }
+    ```
+    
+- The synchronous `loadObject` was removed. Please use `loadObjectAsync` which works the same way
+
+<h2>API 1.0 Full Migration:</h2>
+
+The encouraged way, is to conform to the new API as soon as possible. The following guide will attempt to help with the initial migration from the old API to the new one.
+
+<h3>Extensions:</h3>
+
+A lot of existing viewer functionality has been transferred over to modular `Extensions`. In order to continue to make use of this functionality, the viewer clients now need to explicitly enable extensions by calling `createExtension` with the extension’s constructor as the argument. For example, the complete functionality set requires all the extensions enabled
+
+```jsx
+const cameraController = this.createExtension(CameraController)
+const selection = this.createExtension(LegacySelectionExtension)
+const sections = this.createExtension(SectionTool)
+const sectionOutlines = this.createExtension(SectionOutlines)
+const measurements = this.createExtension(MeasurementsExtension)
+const filtering = this.createExtension(FilteringExtension)
+const explodeExtension = this.createExtension(ExplodeExtension)
+const diffExtension = this.createExtension(DiffExtension)
+```
+
+<h3>General:</h3>
+
+- `ViewerParams`no longer has a `keepGeometryData` property. Redundant geometry data is by default removed and cannot be kept
+- `SectionBoxChanged` and `SectionBoxUpdated` removed from `ViewerEvent` and replaced by `SectionToolEvent.Updated` in `SectionTool` extension
+- `SelectionEvent.hits` changed to `Array<{node: TreeNode, point: Vector3}>`
+- `requestRender` from `Viewer` now takes optional `UpdateFlags`
+- `getObjects` removed from `Viewer`. Similar functionality exists with `getObject` in `SpeckleRenderer`
+- `explode` removed from `Viewer` and replaced by having an `ExplodeExtension` active. Explode time is now controller via `setExplode` in `ExplodeExtension`
+- `getDataTree` and `DataTree` type still exist, but are deprecated and will be soon removed completely. Any functionality can now be replicated with `WorldTree`
+- `cameraHandler` removed from `Viewer` and replaced by `controls` accessor in `CameraController`.
+
+<h3>Section Box:</h3>
+
+- `setSectionBox` removed from `Viewer` and replaced by `setBox` in`SectionTool`
+- `getSectionBoxFromObjects` removed from `Viewer`  and replaced by `boxFromObjects` from `SpeckleRenderer`
+- `getCurrentSectionBox` removed from `Viewer` and replace by `getCurrentBox` in`SectionTool`
+- `toggleSectionBox` removed from `Viewer` and replaced by `toggle` in `SectionTool`
+- `sectionBoxOff` and `sectionBoxOn` removed from `Viewer` and replaced by the `enabled` accessor in `SectionTool`
+
+<h3>Camera:</h3>
+
+- `zoom` removed from `Viewer` and replaced by `setCameraView` in `CameraController` extension
+- `toggleCameraProjection` removed from `Viewer` and replaced by `toggleCameras` in `CameraController` extension
+- `setView` removed from `Viewer` and replaced by `setCameraView` in `CameraController` extension
+- `loadObject` signature changed to `loadObject(loader: Loader, zoomToObject?: boolean)` and it’s now asynchronous
+- `loadObjectAsync` removed from `Viewer`
+
+<h3>Diffing:</h3>
+
+- `diff` removed from `Viewer` and replaced by `diff` in `DiffExtension`
+- `undiff` removed from `Viewer` and replaced by `undiff` in `DiffExtension`
+- `setDiffTime` and `setVisualDiffMode` removed from `Viewer` and replaced by `updateVisualDiff` in `DiffExtension`
+
+<h3>Filtering and Selection:</h3>
+
+- `applyFilter` removed from `Viewer`
+- `getObjectProperties` is now asynchronous
+- `showObjects` and `hideObjects` are removed from `Viewer` and moved to `FilteringExtension`
+- `isolateObjects` and `unIsolateObjects` are removed from `Viewer` and moved to `FilterinExtension`
+- `selectObjects` is removed from `Viewer` and replaced by `selectObjects` in `SelectionExtension`
+- `resetSelection` is removed from `Viewer` and replaced by `clearSelection` in `SelectionExtension`
+- `highlightObjects` and `resetHighlight` are removed from `Viewer`
+- `setColorFilter` ans `removeColorFilter` are removed from `Viewer` and replaced by `setColorFilter`and `removeColorFilter` in `FilteringExtension`
+- `setUserObjectColors` is remove from `Viewer` and replaced by `setUserObjectColors` in `SelectionExtension` but usage is discouraged since paradigm no longer applies
+- `resetFilters`  is removed from `Viewer` and replaced by `resetFilters`  in `SelectionExtension`
+
+<h3>Measurements:</h3>
+
+- `enableMeasurements` removed from `Viewer` and replaced by having a `MeasurementsExtension` active and it’s `enabled` accessor set
+- `setMeasurementOptions` removed from `Viewer` and replaced by the `options` accessor in `MeasurementsExtension`
+- `removeMeasurement` removed from `Viewer` and replaced by `removeMeasurement` in `MeasurementsExtension`

--- a/viewer/migration-guide.md
+++ b/viewer/migration-guide.md
@@ -1,6 +1,13 @@
 # Migration Guide
 
-# 2.15.14 → 2.18.15
+# 2.18.15 → 2.18.16
+- `Vector3Like` replaces `VectorLike` in the arguments of `transformTRS` in `BatchObject`
+- `SpeckleLoader` no longer takes a `priority` argument in it’s constructor
+- `addRenderTree` from `SpeckleRenderer` now takes a `RenderTree` as an argument instead of a `RenderTree` id
+- `getRenderTree` is now overloaded with a version with no arguments that never returns null
+- `intersect` and `intersectRay` arguments have been moved around and both are now overloaded
+
+# 2.18.14 → 2.18.15
 - Asset now has a mandatory ```id``` field
 - `getEnvironment` and `getTexture` from `Assets` now only accept `Asset` as argument
 - The concept of `Providers` has been removed entirely

--- a/viewer/queries-api.md
+++ b/viewer/queries-api.md
@@ -1,0 +1,145 @@
+# Queries
+Queries are a simple mechanism that allows the user to perform several operations in a contained way. The supported operations are 
+- Project a point
+- Unproject a point
+- Intersection test
+- Occlusion test
+
+Queries are not meant to be used directly, but rather through the viewer's [_query_](/viewer/viewer-api.md#query) function
+
+
+### <h3>Typedefs</h3>
+
+| [IntersectionQuery](/viewer/queries-api.md#intersectionquery) | [IntersectionQueryResult](/viewer/queries-api.md#intersectionqueryresult)  | [PointQuery](/viewer/queries-api.md#pointquery) | [PointQueryResult](/viewer/queries-api.md#pointqueryresult)  |
+| :------------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------------- |
+| [Query](/viewer/queries-api.md#query) | [QueryArgsResultMap](/viewer/queries-api.md#queryargsresultmap)   | [QueryOperation](/viewer/queries-api.md#queryoperation) | [QueryResult](/viewer/queries-api.md#queryresult)             
+
+<br>
+<br>
+
+#### <b>IntersectionQuery</b>
+
+```ts
+interface IntersectionQuery extends Query {
+  point: { x: number; y: number; z?: number; w?: number }
+  tolerance?: number
+  operation: 'Occlusion' | 'Pick'
+}
+```
+- **point**: The point to test for intersections
+- _optional_ **tolerance**: Tolerance for intersection
+- **operation**: The query operation type
+
+Based on the operation modes:
+- `Occlusion`: Test if a point in the scene is being occluded by the scene's geometry
+- `Pick`: Cast a camer ray to the specified point and return all intersection results
+<br>
+<br>
+
+#### <b>IntersectionQueryResult</b>
+
+```ts
+interface IntersectionQueryResult {
+  objects: Array<{
+    guid: string
+    object?: Record<string, unknown>
+    point: { x: number; y: number; z: number }
+  }> | null
+}
+```
+- **guid**: The id of the object
+- _optional_ **object**: The raw data of the intersected object
+- **point**: The point of intersection
+<br>
+<br>
+
+#### <b>PointQuery</b>
+
+```ts
+interface PointQuery extends Query {
+  point: { x: number; y: number; z?: number; w?: number }
+  operation: 'Project' | 'Unproject'
+}
+```
+- **point**: The point to run the operation on
+- **operation**: The operation type
+
+Based on the operation modes:
+- `Project`: Projects a world point onto the screen. Result is in NDC
+- `Unproject`: Unprojects an NDC point into a world point
+<br>
+<br>
+
+#### <b>PointQuery</b>
+
+```ts
+interface PointQuery extends Query {
+  point: { x: number; y: number; z?: number; w?: number }
+  operation: 'Project' | 'Unproject'
+}
+```
+- **point**: The point to run the operation on
+- **operation**: The operation type
+
+Based on the operation modes:
+- `Project`: Projects a world point onto the screen. Result is in NDC
+- `Unproject`: Unprojects an NDC point into a world point
+<br>
+<br>
+
+#### <b>PointQueryResult</b>
+
+```ts
+interface PointQueryResult {
+  x: number
+  y: number
+  z?: number
+  w?: number
+}
+```
+The result is a point of variable component length
+<br>
+<br>
+
+#### <b>PointQueryResult</b>
+
+```ts
+interface Query {
+  id?: string 
+  operation: string
+}
+```
+- _optional_ **id**: Currently unused
+- **operation**: The operation type
+<br>
+<br>
+
+#### <b>QueryArgsResultMap</b>
+
+```ts
+type QueryArgsResultMap = {
+  Project: PointQueryResult
+  Unproject: PointQueryResult
+  Occlusion: IntersectionQueryResult
+  Pick: IntersectionQueryResult
+} & { [key: string]: unknown }
+```
+Mapping between the query type and query result type.
+<br>
+<br>
+
+#### <b>QueryOperation</b>
+
+```ts
+type QueryOperation = 'Project' | 'Unproject' | 'Occlusion' | 'Pick'
+```
+Query operation type values
+<br>
+<br>
+
+#### <b>QueryResult</b>
+
+```ts
+type QueryResult = PointQueryResult | IntersectionQueryResult
+```
+Query result type values

--- a/viewer/render-tree-api.md
+++ b/viewer/render-tree-api.md
@@ -55,11 +55,11 @@ Gets the id of the render tree's root node.
 buildRenderTree(geometryConverter: GeometryConverter): Promise<boolean>
 ```
 
-Builds the render tree using the provided [_GeometryConverter_](). Building can be interrupted by calling [_cancelBuild_](/viewer/render-tree-api.md#cancelBuild). 'Building' the render tree, means constructing each node's [_NodeRenderView_](), preparing all geometry and materials, and executing any required transformations. This operation should only be carrired out once, as re-building an already built tree is not possible.
+Builds the render tree using the provided [_GeometryConverter_](/viewer/geometry-converter-api.md). Building can be interrupted by calling [_cancelBuild_](/viewer/render-tree-api.md#cancelBuild). 'Building' the render tree, means constructing each node's [_NodeRenderView_](/viewer/render-view-api.md), preparing all geometry and materials, and executing any required transformations. This operation should only be carrired out once, as re-building an already built tree is not possible.
 
 **Parameters**
 
-- **geometryConverter**: The [_GeometryConverter_]() to use in building the tree
+- **geometryConverter**: The [_GeometryConverter_](/viewer/geometry-converter-api.md) to use in building the tree
 
 **Returns**: <span style="font-weight:normal">A promise which resolves to a boolean indicating if the building process completed successfully (true) or was interrupted (false)</span>
 
@@ -121,11 +121,11 @@ Calls the underlying WorldTree [_getInstances_](/viewer/world-tree-api.md#getins
 getRenderableNodes(...types: SpeckleType[]): TreeNode[]
 ```
 
-Gets all renderable nodes of the specified [_SpeckleType_]()s.
+Gets all renderable nodes of the specified [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype)s.
 
 **Parameters**
 
-- **types**: Variable number of [_SpeckleType_]() values
+- **types**: Variable number of [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype) values
 
 **Returns**: [_TreeNode[]_](/viewer/render-tree-api.md#treenode)
 
@@ -135,13 +135,13 @@ Gets all renderable nodes of the specified [_SpeckleType_]()s.
 getRenderableRenderViews(...types: SpeckleType[]): NodeRenderView[]
 ```
 
-Same as [_getRenderableNodes_](/viewer/render-tree-api.md#getrenderablerenderviews), but returns the mapped [_NodeRenderView_]()s of the renderable nodes.
+Same as [_getRenderableNodes_](/viewer/render-tree-api.md#getrenderablerenderviews), but returns the mapped [_NodeRenderView_](/viewer/render-view-api.md)s of the renderable nodes.
 
 **Parameters**
 
-- **node**: Variable number of [_SpeckleType_]() values
+- **node**: Variable number of [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype) values
 
-**Returns**: [_NodeRenderView[]_]()
+**Returns**: [_NodeRenderView[]_](/viewer/render-view-api.md)
 
 #### <b>getRenderViewNodesForNode</b>
 
@@ -149,7 +149,7 @@ Same as [_getRenderableNodes_](/viewer/render-tree-api.md#getrenderablerendervie
 getRenderViewNodesForNode(node: TreeNode): TreeNode[]
 ```
 
-Returns all [_TreeNode_]()s that have a displayable [_NodeRenderView_]() descending from _node_.
+Returns all [_TreeNode_](/viewer/world-tree-api.md#treenode)s that have a displayable [_NodeRenderView_](/viewer/render-view-api.md) descending from _node_.
 
 **Parameters**
 
@@ -163,13 +163,13 @@ Returns all [_TreeNode_]()s that have a displayable [_NodeRenderView_]() descend
 getRenderViewsForNode(node: TreeNode): NodeRenderView[]
 ```
 
-Gets all displayable [_RenderView_]()s descending from _node_.
+Gets all displayable [_NodeRenderView_](/viewer/render-view-api.md)s descending from _node_.
 
 **Parameters**
 
 - **node**: [_TreeNode_](/viewer/render-tree-api.md#treenode)
 
-**Returns**: [_RenderView[]_]()
+**Returns**: [_NodeRenderView[]_](/viewer/render-view-api.md)
 
 #### <b>getRenderViewsForNodeId</b>
 
@@ -177,13 +177,13 @@ Gets all displayable [_RenderView_]()s descending from _node_.
 getRenderViewsForNodeId(id: string): NodeRenderView[]
 ```
 
-Gets all displayable [_RenderView_]()s descending from the node with the provided _id_.
+Gets all displayable [_NodeRenderView_](/viewer/render-view-api.md)s descending from the node with the provided _id_.
 
 **Parameters**
 
-- **id**: Id of the node to gather [_RenderView_]()s for
+- **id**: Id of the node to gather [_NodeRenderView_](/viewer/render-view-api.md)s for
 
-**Returns**: [_RenderView[]_]()
+**Returns**: [_NodeRenderView[]_](/viewer/render-view-api.md)
 
 #### <b>purge</b>
 

--- a/viewer/render-view-api.md
+++ b/viewer/render-view-api.md
@@ -158,9 +158,9 @@ Gets the render view's computed material hash.
 get speckleType(): SpeckleType
 ```
 
-Gets the render view's render data [_SpeckleType_]().
+Gets the render view's render data [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype).
 
-**Returns**: [_SpeckleType_]()
+**Returns**: [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype)
 
 #### <b>transparent</b>
 
@@ -276,10 +276,10 @@ This is the bare bones data representation of anything renderable in the viewer.
 
 - **id**: The id of the object. For speckle data, this would be the speckle id
 - **subtreeId**: The id of the subtree of the host node
-- **speckleType**: [_SpeckleType_]()
+- **speckleType**: [_SpeckleType_](/viewer/geometry-converter-api.md#speckletype)
 - **geometry**: Raw geometry information stored as [_GeometryData_](/viewer/render-view-api.md#geometrydata)
-- **renderMaterial**: Raw material information stored as [_RenderMaterial_]()
-- **DisplayStyle**: Raw line material information stored as [_DisplayStyle_]()
+- **renderMaterial**: Raw material information stored as [_RenderMaterial_](/viewer/speckle-material-api.md#rendermaterial)
+- **DisplayStyle**: Raw line material information stored as [_DisplayStyle_](/viewer/speckle-material-api.md#displaystyle)
 
 #### <b>GeometryData</b>
 
@@ -295,7 +295,7 @@ interface GeometryData {
 
 Raw geometry information, explicit and/or implicit.
 
-- **attributes**: [_GeometryAttributes_]() Vertex attribute arrays
+- **attributes**: [_GeometryAttributes_](/viewer/render-view-api.md#geometryattributes) Vertex attribute arrays
 - **bakeTransform**: [_Matrix4_](https://threejs.org/docs/index.html?q=matri#api/en/math/Matrix4) transformation that will get baked into the geometry
 - **transform**: [_Matrix4_](https://threejs.org/docs/index.html?q=matri#api/en/math/Matrix4) the object's transformation. As per the default implementation, instances use this as the per instance transform attribute. Non-instances have it baked in their geometries
 - **metaData**: Implicit geometry data which the viewer uses at runtime to create geometry. Text is a good example of implicit geometry

--- a/viewer/section-tool-api.md
+++ b/viewer/section-tool-api.md
@@ -2,7 +2,7 @@
 
 Default section tool implementation.
 :::warning
-Requires ICameraProvider implementation.
+This extension requires and active CameraController extension implementation.
 :::
 
 ### <h3>Accessors</h3>
@@ -60,14 +60,14 @@ Gets the current section box bounds.
 #### <b>on</b>
 
 ```ts
-on(e: CameraControllerEvent, handler: (data: boolean) => void)
+on(e: CameraEvent, handler: (data: boolean) => void)
 ```
 
 Function for subscribing to camera events.
 
 **Parameters**
 
-- **e**: [_CameraControllerEvent_]()
+- **e**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
 - **handler**: The handler for the events
 
 **Returns**: void
@@ -75,14 +75,14 @@ Function for subscribing to camera events.
 #### <b>removeListener</b>
 
 ```ts
-removeListener(e: CameraControllerEvent, handler: (data: unknown) => void)
+removeListener(e: CameraEvent, handler: (data: unknown) => void)
 ```
 
 Function for un-subscribing from camera events.
 
 **Parameters**
 
-- **e**: [_CameraControllerEvent_]()
+- **e**: [_CameraEvent_](/viewer/camera-controller-api.md#cameraevent)
 - **handler**: The handler for the events to unsubscribe
 
 **Returns**: void

--- a/viewer/section-tool-api.md
+++ b/viewer/section-tool-api.md
@@ -18,8 +18,8 @@ This extension requires and active CameraController extension implementation.
 
 ### <h3>Typedefs</h3>
 
-| [SectionToolEvent](/viewer/section-tool-api.md#sectiontoolevent) |
-| ----------------------------------------------------------------------- |
+| [SectionToolEvent](/viewer/section-tool-api.md#sectiontoolevent) | [SectionToolEventPayload](/viewer/section-tool-api.md#sectiontooleventpayload)
+| :----------------------------------------------------------------------- | :---------------------------------------- | 
 
 ### <h3>Accessors</h3>
 
@@ -124,3 +124,15 @@ enum SectionToolEvent {
 ```
 
 Events that the extension can emit.
+
+#### <b>SectionToolEventPayload</b>
+
+```ts
+interface SectionToolEventPayload {
+  [SectionToolEvent.DragStart]: void
+  [SectionToolEvent.DragEnd]: void
+  [SectionToolEvent.Updated]: Plane[]
+}
+```
+
+Mapping SectionToolEvent types to handler argument type

--- a/viewer/section-tool-outlines-api.md
+++ b/viewer/section-tool-outlines-api.md
@@ -1,5 +1,22 @@
 # SectionToolOutlines
 
+This extension adds outlines to the section tool's sectioned geometry edges. 
 :::warning
-This extension adds outlines to the section tool's sectioned geometry edges. **It does not have a public API as of yet**.
+This extension requires and active SectionTool extension.
 :::
+
+### <h3>Accessors</h3>
+
+| [enabled](/viewer/section-tool-outlines-api.md#enabled) 
+| ----------------------------------------------------- | 
+
+#### <b>enabled</b>
+
+```ts
+get enabled(): boolean
+set enabled(value: boolean)
+```
+
+Enables/disables the extension.
+
+**Returns**: boolean

--- a/viewer/selection-extension-api.md
+++ b/viewer/selection-extension-api.md
@@ -8,7 +8,7 @@ The extension automatically binds to:
 - `InputEvent.PointerMove` for hover detection
 
 :::warning
-Requires an existing `ICameraProvider` implementation.
+This extension requires and active CameraController extension implementation.
 :::
 
 ### <h3>Accessors</h3>

--- a/viewer/speckle-renderer-api.md
+++ b/viewer/speckle-renderer-api.md
@@ -89,9 +89,9 @@ Sets the [_envMapIntensity_](https://threejs.org/docs/index.html?q=standard#api/
 get intersections(): Intersections
 ```
 
-Gets the [_Intersections_]() instance associated with the renderer.
+Gets the [_Intersections_](/viewer/intersections-api.md) instance associated with the renderer.
 
-**Returns**: [**_Intersections_**]()
+**Returns**: [**_Intersections_**](/viewer/intersections-api.md)
 
 #### <b>needsRender</b>
 

--- a/viewer/top-level-acceleration-structure-api.md
+++ b/viewer/top-level-acceleration-structure-api.md
@@ -21,8 +21,8 @@ The speckle viewer uses a dual level BVH for optimal acceleration. The TopLevelA
 
 ### <h3>Typedefs</h3>
 
-| [ExtendedIntersection](/viewer/top-level-acceleration-structure-api.md#extendedintersection) | [ExtendedShapeCastCallbacks](/viewer/top-level-acceleration-structure-api.md#extendedshapecastcallbacks) |
-| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+[ExtendedShapeCastCallbacks](/viewer/top-level-acceleration-structure-api.md#extendedshapecastcallbacks) |
+| -------------------------------------------------------------------------------------------- | 
 
 ### <h3>Constructors</h3>
 
@@ -133,17 +133,6 @@ Generic mechanism to intersect the BVH with various shapes/objects. The callback
 **Returns**: boolean
 
 ### <h3>Typedefs</h3>
-
-#### <b>ExtendedIntersection</b>
-
-```ts
-interface ExtendedIntersection extends Intersection {
-  batchObject?: BatchObject;
-  material?: Material;
-}
-```
-
-Extension of three.js's default Intersection.
 
 #### <b>ExtendedShapeCastCallbacks</b>
 

--- a/viewer/viewer-api.md
+++ b/viewer/viewer-api.md
@@ -31,7 +31,7 @@ background-color: rgba(0, 0, 0, 0.0) !important;
 | [LightConfiguration](/viewer/viewer-api.md#lightconfiguration) | [ObjectLayers](/viewer/viewer-api.md#objectlayers)  | [PropertyInfo](/viewer/viewer-api.md#propertyinfo) | [SelectionEvent](/viewer/viewer-api.md#selectionevent) |
 | :------------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------------- |
 | [SpeckleView](/viewer/viewer-api.md#speckleview)               | [SunLightConfiguration](/viewer/viewer-api.md#sunlightconfiguration) | [UpdateFlags](/viewer/viewer-api.md#updateflags)   | [Utils](/viewer/viewer-api.md#utilsinterface)          |
-| [ViewerEvent](/viewer/viewer-api.md#viewerevent)               | [ViewerParams](/viewer/viewer-api.md#viewerparams)                   | [World](/viewer/viewer-api.md#worldclass)          |
+| [ViewerEvent](/viewer/viewer-api.md#viewerevent)               | [ViewerParams](/viewer/viewer-api.md#viewerparams)                   | [World](/viewer/viewer-api.md#worldclass)          | [Asset](/viewer/viewer-api.md#asset)
 
 ### <h3>Constructors</h3>
 
@@ -151,9 +151,9 @@ When executing for a very large number of objects, this method can take long to 
 getRenderer(): SpeckleRenderer
 ```
 
-Gets the [_SpeckleRenderer_]() instance associated with the viewer.
+Gets the [_SpeckleRenderer_](/viewer/speckle-renderer-api.md) instance associated with the viewer.
 
-**Returns**: [_SpeckleRenderer_]()
+**Returns**: [_SpeckleRenderer_](/viewer/speckle-renderer-api.md)
 
 #### <b>getViews</b>
 
@@ -171,9 +171,9 @@ Gets all the current [_SpeckleView_](/viewer/viewer-api.md#speckleview) instance
 getWorldTree(): WorldTree
 ```
 
-Gets the [_WorldTree_]() instance associated with the viewer.
+Gets the [_WorldTree_](/viewer/world-tree-api.md) instance associated with the viewer.
 
-**Returns**: [_WorldTree[]_]()
+**Returns**: [_WorldTree[]_](/viewer/world-tree-api.md)
 
 #### <b>init</b>
 
@@ -191,11 +191,11 @@ Initializes the viewer asynchronously and loads required assets.
 loadObject(loader: Loader, zoomToObject?: boolean): Promise<void>
 ```
 
-Loads objects asynchronously using a [_Loader_]().
+Loads objects asynchronously using a [_Loader_](/viewer/loader-api.md).
 
 **Parameters**
 
-- **loader**: The [_Loader_]() instance used in loading.
+- **loader**: The [_Loader_](/viewer/loader-api.md) instance used in loading.
 - _(optional)_ **zoomToObject**: Enabled zooming in on the loaded object after loading finishes. Default _true_
 
 **Returns**: <span style="font-weight:normal">_Promise< void >_</span>
@@ -371,7 +371,7 @@ Payload for _ViewerEvent.ObjectClicked_ and _ViewerEvent.ObjectDoubleClicked_.
 
 - **multiple**: Whether this is a multiple selection or not.
 - **event**: The browser [_PointerEvent_](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) piggybacked.
-- **hits**: The array of hits sorted by distance, where closest is first. _node_ is the intersected [_TreeNode_]() and _point_ is it's point of intersection.
+- **hits**: The array of hits sorted by distance, where closest is first. _node_ is the intersected [_TreeNode_](/viewer/world-tree-api.md#treenode) and _point_ is it's point of intersection.
 
 #### <b>SpeckleView</b>
 
@@ -399,7 +399,7 @@ interface SunLightConfiguration extends LightConfiguration {
 
 - **elevation**: Sun elevation in polar coordinates.
 - **azimuth**: Sun azimuth in polar coordinates.
-- **radius**: Sun distance from [_World_]() center.
+- **radius**: Sun distance from [_World_](/viewer/viewer-api.md#worldclass) center.
 
 #### <b>UpdateFlags</b>
 
@@ -458,7 +458,7 @@ All the events the viewer can emit.
 ```ts
 interface ViewerParams {
   showStats: boolean;
-  environmentSrc: Asset | string;
+  environmentSrc: Asset;
   verbose: boolean;
 }
 ```
@@ -466,6 +466,30 @@ interface ViewerParams {
 - **showStats**: Displays a [stats](https://github.com/mrdoob/stats.js) panel.
 - **environmentSrc**: The URL of the image used for indirect IBL.
 - **verbose**: Enables viewer logs.
+
+#### <b>Asset</b>
+
+```ts
+enum AssetType {
+  TEXTURE_8BPP = 'png', 
+  TEXTURE_HDR = 'hdr',
+  TEXTURE_EXR = 'exr',
+  FONT_JSON = 'font-json'
+}
+
+interface Asset {
+  id: string
+  src: string
+  type: AssetType
+}
+```
+
+- **id**: Mandatory id of the asset.
+- **src**: The URL of the asset. Supports inline base64 encoded assets
+- **type**: _AssetType_
+:::warning
+For correct asset caching use need to use unique asset ids!
+:::
 
 #### <b>WorldClass</b>
 

--- a/viewer/viewer-api.md
+++ b/viewer/viewer-api.md
@@ -22,16 +22,17 @@ background-color: rgba(0, 0, 0, 0.0) !important;
 | [cancelLoad](/viewer/viewer-api.md#cancelload)  | [createExtension](/viewer/viewer-api.md#createextension) | [dispose](/viewer/viewer-api.md#dispose) | [getContainer](/viewer/viewer-api.md#getcontainer) |
 | :------------------------------------------------------------------- | :--------------------------------------------------------------- | :------------------------------------------------- | :------------------------------------------------- |
 | [getExtension](/viewer/viewer-api.md#getextension)                   | [getObjectProperties](/viewer/viewer-api.md#getobjectproperties) | [getRenderer](/viewer/viewer-api.md#getrenderer)   | [getViews](/viewer/viewer-api.md#getviews)         |
-| [getWorldTree](/viewer/viewer-api.md#getworldtree)                   | [init](/viewer/viewer-api.md#init)                               | [loadObject](/viewer/viewer-api.md#loadObject)     | [on](/viewer/viewer-api.md#on)                     |
-| [query](/viewer/viewer-api.md#query)                                 | [requestRender](/viewer/viewer-api.md#requestrender)             | [resize](/viewer/viewer-api.md#resize)             | [screenshot](/viewer/viewer-api.md#screenshot)     |
-| [setLightConfiguration](/viewer/viewer-api.md#setlightconfiguration) | [unloadAll](/viewer/viewer-api.md#unloadall)                     | [unloadObject](/viewer/viewer-api.md#unloadobject) |
+| [getWorldTree](/viewer/viewer-api.md#getworldtree)                   | [hasExtension](/viewer/viewer-api.md#hasextension)                               | [init](/viewer/viewer-api.md#init)     | [loadObject](/viewer/viewer-api.md#loadObject)                     |
+| [on](/viewer/viewer-api.md#on)                                 | [query](/viewer/viewer-api.md#query)             | [requestRender](/viewer/viewer-api.md#requestrender)             | [resize](/viewer/viewer-api.md#resize)     |
+| [screenshot](/viewer/viewer-api.md#screenshot) | [setLightConfiguration](/viewer/viewer-api.md#setlightconfiguration)                     | [unloadAll](/viewer/viewer-api.md#unloadall) | [unloadObject](/viewer/viewer-api.md#unloadobject)
 
 ### <h3>Typedefs</h3>
 
-| [LightConfiguration](/viewer/viewer-api.md#lightconfiguration) | [ObjectLayers](/viewer/viewer-api.md#objectlayers)  | [PropertyInfo](/viewer/viewer-api.md#propertyinfo) | [SelectionEvent](/viewer/viewer-api.md#selectionevent) |
+| [Asset](/viewer/viewer-api.md#asset) | [LightConfiguration](/viewer/viewer-api.md#lightconfiguration)  | [ObjectLayers](/viewer/viewer-api.md#objectlayers) | [PropertyInfo](/viewer/viewer-api.md#propertyinfo) |
 | :------------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------- | :----------------------------------------------------- |
-| [SpeckleView](/viewer/viewer-api.md#speckleview)               | [SunLightConfiguration](/viewer/viewer-api.md#sunlightconfiguration) | [UpdateFlags](/viewer/viewer-api.md#updateflags)   | [Utils](/viewer/viewer-api.md#utilsinterface)          |
-| [ViewerEvent](/viewer/viewer-api.md#viewerevent)               | [ViewerParams](/viewer/viewer-api.md#viewerparams)                   | [World](/viewer/viewer-api.md#worldclass)          | [Asset](/viewer/viewer-api.md#asset)
+| [SelectionEvent](/viewer/viewer-api.md#selectionevent)               | [SpeckleView](/viewer/viewer-api.md#speckleview) | [SunLightConfiguration](/viewer/viewer-api.md#sunlightconfiguration)   | [UpdateFlags](/viewer/viewer-api.md#updateflags)          |
+| [Utils](/viewer/viewer-api.md#utilsinterface)               | [ViewerEvent](/viewer/viewer-api.md#viewerevent)                   | [ViewerEventPayload](/viewer/viewer-api.md#viewereventpayload)          | [ViewerParams](/viewer/viewer-api.md#viewerparams)
+| [World](/viewer/viewer-api.md#worldclass)
 
 ### <h3>Constructors</h3>
 
@@ -175,6 +176,17 @@ Gets the [_WorldTree_](/viewer/world-tree-api.md) instance associated with the v
 
 **Returns**: [_WorldTree[]_](/viewer/world-tree-api.md)
 
+#### <b>hasExtension</b>
+
+```ts
+hasExtension<T extends Extension>(type: Constructor<T>): boolean
+```
+
+Returns `true` if specified extension type exists, `false` otherwise
+
+**Returns**: _boolean_
+
+
 #### <b>init</b>
 
 ```ts
@@ -203,7 +215,10 @@ Loads objects asynchronously using a [_Loader_](/viewer/loader-api.md).
 #### <b>on</b>
 
 ```ts
-on(eventType: ViewerEvent, handler: (arg) => void)
+on<T extends ViewerEvent>(
+  eventType: T,
+  handler: (arg: ViewerEventPayload[T]) => void
+): void
 ```
 
 Subscribes handlers to [_ViewerEvent_](/viewer/viewer-api.md#viewerevent)s.
@@ -453,6 +468,22 @@ enum ViewerEvent {
 
 All the events the viewer can emit.
 
+#### <b>ViewerEventPayload</b>
+
+```ts
+interface ViewerEventPayload {
+  [ViewerEvent.ObjectClicked]: SelectionEvent | null
+  [ViewerEvent.ObjectDoubleClicked]: SelectionEvent | null
+  [ViewerEvent.LoadComplete]: string
+  [ViewerEvent.UnloadComplete]: string
+  [ViewerEvent.UnloadAllComplete]: void
+  [ViewerEvent.Busy]: boolean
+  [ViewerEvent.FilteringStateSet]: FilteringState
+  [ViewerEvent.LightConfigUpdated]: LightConfiguration
+}
+```
+
+Mapping of viewer events to event handler argument types
 #### <b>ViewerParams</b>
 
 ```ts
@@ -503,6 +534,7 @@ class World {
   reduceWorld(box: Box3)
   updateWorld()
   resetWorld()
+  getRelativeOffset(offsetAmount: number = 0.001): number
 ```
 
 Utility class for keeping track of the total dimensions of loaded objects. It's mostly used for informative purposes

--- a/viewer/world-tree-api.md
+++ b/viewer/world-tree-api.md
@@ -96,7 +96,7 @@ findAll(predicate: SearchPredicate, node?: TreeNode): TreeNode[]
 
 Goes throught the tree starting at _node_ if provided, otherwise at the tree _root_ and runs the provided predicate for each node. All nodes which satisfy the predicate are returned.
 ::: warning
-Be mindful about the predicate's contents. If the tree is very large this operation can lock the main thread for too long. If you need to execute complex predicates on large trees, [_walkAsync_]() is a better candidate.
+Be mindful about the predicate's contents. If the tree is very large this operation can lock the main thread for too long. If you need to execute complex predicates on large trees, [_walkAsync_](/viewer/world-tree-api.md#walkasync) is a better candidate.
 :::
 
 **Parameters**
@@ -158,13 +158,13 @@ Gets all the instances in the provided subtree id.
 getRenderTree(subtreeId?: string): RenderTree
 ```
 
-Gets the [_RenderTree_]() instance of the provided subtree id. If _subtreeId_ argument is undefined, gets the _RenderTree_ instance for the entire tree.
+Gets the [_RenderTree_](/viewer/render-tree-api.md) instance of the provided subtree id. If _subtreeId_ argument is undefined, gets the _RenderTree_ instance for the entire tree.
 
 **Parameters**
 
 - **subtreeId**: The root subtree id
 
-**Returns**: [_RenderTree_]()
+**Returns**: [_RenderTree_](/viewer/render-tree-api.md)
 
 #### <b>isRoot</b>
 

--- a/viewer/world-tree-api.md
+++ b/viewer/world-tree-api.md
@@ -155,10 +155,11 @@ Gets all the instances in the provided subtree id.
 #### <b>getRenderTree</b>
 
 ```ts
-getRenderTree(subtreeId?: string): RenderTree
+getRenderTree(): RenderTree
+getRenderTree(subtreeId: string): RenderTree | null
 ```
 
-Gets the [_RenderTree_](/viewer/render-tree-api.md) instance of the provided subtree id. If _subtreeId_ argument is undefined, gets the _RenderTree_ instance for the entire tree.
+Gets the [_RenderTree_](/viewer/render-tree-api.md) instance of the provided subtree id. If the subtree id is not found, `null` is returned. The overloaded version with no argument gets the _RenderTree_ instance for the entire tree, which can never be null. 
 
 **Parameters**
 


### PR DESCRIPTION
- Added API migration guide
- Added API reference for `Queries` and `Extension` which were still missing
- Update missing link across all viewer docs
- Added 2.18.15 migration notes and updated documentation accordingly
- Added 2.18.16 migration notes and updated documentation accordingly